### PR TITLE
feat: add reconnect window to recording config

### DIFF
--- a/cdk/config.json
+++ b/cdk/config.json
@@ -1,5 +1,6 @@
 {
   "region": "us-east-1",
   "channelType": "BASIC",
+  "reconnectWindowSeconds": 60,
   "allowedOrigins": ["http://localhost:3000"]
 }

--- a/cdk/lib/vod-rendition-playlist-stack.ts
+++ b/cdk/lib/vod-rendition-playlist-stack.ts
@@ -35,6 +35,7 @@ export class DVRdemoStack extends Stack {
       {
         name: 'dvr-recording-config',
         destinationConfiguration: { s3: { bucketName: vodBucketName } },
+        recordingReconnectWindowSeconds: 60,
         thumbnailConfiguration: { recordingMode: 'DISABLED' }
       }
     );

--- a/cdk/lib/vod-rendition-playlist-stack.ts
+++ b/cdk/lib/vod-rendition-playlist-stack.ts
@@ -13,7 +13,11 @@ import {
 } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
-import { allowedOrigins, channelType } from '../config.json';
+import {
+  allowedOrigins,
+  channelType,
+  reconnectWindowSeconds
+} from '../config.json';
 import { getLambdaEntryPath } from './utils';
 
 export class DVRdemoStack extends Stack {
@@ -35,7 +39,7 @@ export class DVRdemoStack extends Stack {
       {
         name: 'dvr-recording-config',
         destinationConfiguration: { s3: { bucketName: vodBucketName } },
-        recordingReconnectWindowSeconds: 60,
+        recordingReconnectWindowSeconds: reconnectWindowSeconds,
         thumbnailConfiguration: { recordingMode: 'DISABLED' }
       }
     );

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -1,38 +1,53 @@
 {
   "name": "cdk",
   "version": "0.1.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cdk",
       "version": "0.1.0",
       "dependencies": {
-        "@aws-sdk/client-ivs": "^3.58.0",
-        "@aws-sdk/client-s3": "^3.58.0",
-        "aws-cdk-lib": "^2.19.0",
-        "constructs": "^10.0.106",
-        "source-map-support": "^0.5.16"
+        "@aws-sdk/client-ivs": "^3.345.0",
+        "@aws-sdk/client-s3": "^3.345.0",
+        "aws-cdk-lib": "^2.82.0",
+        "constructs": "^10.2.44",
+        "source-map-support": "^0.5.21"
       },
       "bin": {
         "cdk": "bin/cdk.js"
       },
       "devDependencies": {
-        "@types/aws-lambda": "^8.10.93",
+        "@types/aws-lambda": "^8.10.116",
         "@types/node": "17.0.23",
-        "aws-cdk": "^2.19.0",
-        "esbuild": "^0.14.31",
-        "ts-node": "^10.7.0",
-        "typescript": "^4.6.3"
+        "aws-cdk": "^2.82.0",
+        "esbuild": "^0.14.54",
+        "ts-node": "^10.9.1",
+        "typescript": "^4.9.5"
       }
     },
+    "node_modules/@aws-cdk/asset-awscli-v1": {
+      "version": "2.2.186",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.186.tgz",
+      "integrity": "sha512-2wSuOWQlrWc0AFuPCzXYn2Y8oK2vTfpNrVa8dxBxfswbwUrXMAirhpsP1f1J/4KEhA/4Hs4l27dKiC/IcDrvIQ=="
+    },
+    "node_modules/@aws-cdk/asset-kubectl-v20": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.1.tgz",
+      "integrity": "sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw=="
+    },
+    "node_modules/@aws-cdk/asset-node-proxy-agent-v5": {
+      "version": "2.0.155",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.155.tgz",
+      "integrity": "sha512-Q+Ny25hUPINlBbS6lmbUr4m6Tr6ToEJBla7sXA3FO3JUD0Z69ddcgbhuEBF8Rh1a2xmPONm89eX77kwK2fb4vQ=="
+    },
     "node_modules/@aws-crypto/crc32": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-2.0.0.tgz",
-      "integrity": "sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
       "dependencies": {
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
         "tslib": "^1.11.1"
       }
     },
@@ -42,12 +57,12 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/crc32c": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-2.0.0.tgz",
-      "integrity": "sha512-vF0eMdMHx3O3MoOXUfBZry8Y4ZDtcuskjjKgJz8YfIDjLStxTZrYXk+kZqtl6A0uCmmiN/Eb/JbC/CndTV1MHg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-3.0.0.tgz",
+      "integrity": "sha512-ENNPPManmnVJ4BTXlOjAgD7URidbAznURqD0KvfREyc4o20DPYdEldU1f5cQ7Jbj0CJJSPaMIk/9ZshdB3210w==",
       "dependencies": {
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
         "tslib": "^1.11.1"
       }
     },
@@ -57,9 +72,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/ie11-detection": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
-      "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -70,13 +85,14 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/sha1-browser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-2.0.0.tgz",
-      "integrity": "sha512-3fIVRjPFY8EG5HWXR+ZJZMdWNRpwbxGzJ9IH9q93FpbgCH8u8GHRi46mZXp3cYD7gealmyqpm3ThZwLKJjWJhA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-3.0.0.tgz",
+      "integrity": "sha512-NJth5c997GLHs6nOYTzFKTbYdMNA6/1XlKVgnZoaZcQ7z7UJlOgj2JdbHE8tiYLS3fzXNCguct77SPGat2raSw==",
       "dependencies": {
-        "@aws-crypto/ie11-detection": "^2.0.0",
-        "@aws-crypto/supports-web-crypto": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
@@ -88,15 +104,15 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/sha256-browser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
-      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
       "dependencies": {
-        "@aws-crypto/ie11-detection": "^2.0.0",
-        "@aws-crypto/sha256-js": "^2.0.0",
-        "@aws-crypto/supports-web-crypto": "^2.0.0",
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
@@ -108,12 +124,12 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/sha256-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
-      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
       "dependencies": {
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
         "tslib": "^1.11.1"
       }
     },
@@ -123,9 +139,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
-      "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -136,11 +152,11 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/util": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
-      "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
       "dependencies": {
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
@@ -151,630 +167,897 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.55.0.tgz",
-      "integrity": "sha512-rCcTxJDEFnmvo/PgbhCRv24/Uv03lEGfRslKZq7SjaMcOubflS/ZXYaMEgsjYHgAT0zlpSsyCIkJXmhFaM7H7w==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.342.0.tgz",
+      "integrity": "sha512-W1lAYldbzDjfn8vwnwNe+6qNWfSu1+JrdiVIRSwsiwKvF2ahjKuaLoc8rJM09C6ieNWRi5634urFgfwAJuv6vg==",
       "dependencies": {
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/chunked-blob-reader": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.55.0.tgz",
-      "integrity": "sha512-o/xjMCq81opAjSBjt7YdHJwIJcGVG5XIV9+C2KXcY5QwVimkOKPybWTv0mXPvSwSilSx+EhpLNhkcJuXdzhw4w==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.310.0.tgz",
+      "integrity": "sha512-CrJS3exo4mWaLnWxfCH+w88Ou0IcAZSIkk4QbmxiHl/5Dq705OLoxf4385MVyExpqpeVJYOYQ2WaD8i/pQZ2fg==",
       "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/chunked-blob-reader-native": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.58.0.tgz",
-      "integrity": "sha512-+D3xnPD5985iphgAqgUerBDs371a2WzzoEVi7eHJUMMsP/gEnSTdSH0HNxsqhYv6CW4EdKtvDAQdAwA1VtCf2A==",
-      "dependencies": {
-        "@aws-sdk/util-base64-browser": "3.58.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/client-ivs": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ivs/-/client-ivs-3.58.0.tgz",
-      "integrity": "sha512-3h7n1avdHDKOjTKf2s3Wn7uKd/bvnZjGDxjbePPBN0I/QZw10k++mtJNIzmO3yom5ZzKjDBoyZ+9qCxmnazDlg==",
+      "version": "3.345.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ivs/-/client-ivs-3.345.0.tgz",
+      "integrity": "sha512-NMi9XWfmuyAkj4ro1k9SEUj+R2hJ7+BqFCsp0nv2Nymi/9GqccrlF82ceg8c85daNWk4daYM6bwo1LYrKffiqg==",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.58.0",
-        "@aws-sdk/config-resolver": "3.58.0",
-        "@aws-sdk/credential-provider-node": "3.58.0",
-        "@aws-sdk/fetch-http-handler": "3.58.0",
-        "@aws-sdk/hash-node": "3.55.0",
-        "@aws-sdk/invalid-dependency": "3.55.0",
-        "@aws-sdk/middleware-content-length": "3.58.0",
-        "@aws-sdk/middleware-host-header": "3.58.0",
-        "@aws-sdk/middleware-logger": "3.55.0",
-        "@aws-sdk/middleware-retry": "3.58.0",
-        "@aws-sdk/middleware-serde": "3.55.0",
-        "@aws-sdk/middleware-signing": "3.58.0",
-        "@aws-sdk/middleware-stack": "3.55.0",
-        "@aws-sdk/middleware-user-agent": "3.58.0",
-        "@aws-sdk/node-config-provider": "3.58.0",
-        "@aws-sdk/node-http-handler": "3.58.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/smithy-client": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/url-parser": "3.55.0",
-        "@aws-sdk/util-base64-browser": "3.58.0",
-        "@aws-sdk/util-base64-node": "3.55.0",
-        "@aws-sdk/util-body-length-browser": "3.55.0",
-        "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.55.0",
-        "@aws-sdk/util-defaults-mode-node": "3.58.0",
-        "@aws-sdk/util-user-agent-browser": "3.58.0",
-        "@aws-sdk/util-user-agent-node": "3.58.0",
-        "@aws-sdk/util-utf8-browser": "3.55.0",
-        "@aws-sdk/util-utf8-node": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.345.0",
+        "@aws-sdk/config-resolver": "3.342.0",
+        "@aws-sdk/credential-provider-node": "3.345.0",
+        "@aws-sdk/fetch-http-handler": "3.342.0",
+        "@aws-sdk/hash-node": "3.344.0",
+        "@aws-sdk/invalid-dependency": "3.342.0",
+        "@aws-sdk/middleware-content-length": "3.342.0",
+        "@aws-sdk/middleware-endpoint": "3.344.0",
+        "@aws-sdk/middleware-host-header": "3.342.0",
+        "@aws-sdk/middleware-logger": "3.342.0",
+        "@aws-sdk/middleware-recursion-detection": "3.342.0",
+        "@aws-sdk/middleware-retry": "3.342.0",
+        "@aws-sdk/middleware-serde": "3.342.0",
+        "@aws-sdk/middleware-signing": "3.342.0",
+        "@aws-sdk/middleware-stack": "3.342.0",
+        "@aws-sdk/middleware-user-agent": "3.345.0",
+        "@aws-sdk/node-config-provider": "3.342.0",
+        "@aws-sdk/node-http-handler": "3.344.0",
+        "@aws-sdk/smithy-client": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/url-parser": "3.342.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.342.0",
+        "@aws-sdk/util-defaults-mode-node": "3.342.0",
+        "@aws-sdk/util-endpoints": "3.342.0",
+        "@aws-sdk/util-retry": "3.342.0",
+        "@aws-sdk/util-user-agent-browser": "3.345.0",
+        "@aws-sdk/util-user-agent-node": "3.345.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.58.0.tgz",
-      "integrity": "sha512-7TAqYFpFeaahLCdIxsdWLz3uRrzITFFFitbfVxQ+eaR6EMuH3VEhbGEZ66+zieWns9a1UXc11918vpwgu0zTtw==",
+      "version": "3.345.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.345.0.tgz",
+      "integrity": "sha512-Vj1QGTkFOaWMP9jTVXX9NcNxLw1XY8w4hCXtQAzuUTepfqvA8K/EjeVhpG3Tc0tONeuPe4ee+2T1Q0BCKnf25w==",
       "dependencies": {
-        "@aws-crypto/sha1-browser": "2.0.0",
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.58.0",
-        "@aws-sdk/config-resolver": "3.58.0",
-        "@aws-sdk/credential-provider-node": "3.58.0",
-        "@aws-sdk/eventstream-serde-browser": "3.58.0",
-        "@aws-sdk/eventstream-serde-config-resolver": "3.55.0",
-        "@aws-sdk/eventstream-serde-node": "3.58.0",
-        "@aws-sdk/fetch-http-handler": "3.58.0",
-        "@aws-sdk/hash-blob-browser": "3.58.0",
-        "@aws-sdk/hash-node": "3.55.0",
-        "@aws-sdk/hash-stream-node": "3.58.0",
-        "@aws-sdk/invalid-dependency": "3.55.0",
-        "@aws-sdk/md5-js": "3.58.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.58.0",
-        "@aws-sdk/middleware-content-length": "3.58.0",
-        "@aws-sdk/middleware-expect-continue": "3.58.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.58.0",
-        "@aws-sdk/middleware-host-header": "3.58.0",
-        "@aws-sdk/middleware-location-constraint": "3.55.0",
-        "@aws-sdk/middleware-logger": "3.55.0",
-        "@aws-sdk/middleware-retry": "3.58.0",
-        "@aws-sdk/middleware-sdk-s3": "3.58.0",
-        "@aws-sdk/middleware-serde": "3.55.0",
-        "@aws-sdk/middleware-signing": "3.58.0",
-        "@aws-sdk/middleware-ssec": "3.55.0",
-        "@aws-sdk/middleware-stack": "3.55.0",
-        "@aws-sdk/middleware-user-agent": "3.58.0",
-        "@aws-sdk/node-config-provider": "3.58.0",
-        "@aws-sdk/node-http-handler": "3.58.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/smithy-client": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/url-parser": "3.55.0",
-        "@aws-sdk/util-base64-browser": "3.58.0",
-        "@aws-sdk/util-base64-node": "3.55.0",
-        "@aws-sdk/util-body-length-browser": "3.55.0",
-        "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.55.0",
-        "@aws-sdk/util-defaults-mode-node": "3.58.0",
-        "@aws-sdk/util-stream-browser": "3.55.0",
-        "@aws-sdk/util-stream-node": "3.55.0",
-        "@aws-sdk/util-user-agent-browser": "3.58.0",
-        "@aws-sdk/util-user-agent-node": "3.58.0",
-        "@aws-sdk/util-utf8-browser": "3.55.0",
-        "@aws-sdk/util-utf8-node": "3.55.0",
-        "@aws-sdk/util-waiter": "3.55.0",
-        "@aws-sdk/xml-builder": "3.55.0",
-        "entities": "2.2.0",
-        "fast-xml-parser": "3.19.0",
-        "tslib": "^2.3.1"
+        "@aws-crypto/sha1-browser": "3.0.0",
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.345.0",
+        "@aws-sdk/config-resolver": "3.342.0",
+        "@aws-sdk/credential-provider-node": "3.345.0",
+        "@aws-sdk/eventstream-serde-browser": "3.342.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.342.0",
+        "@aws-sdk/eventstream-serde-node": "3.342.0",
+        "@aws-sdk/fetch-http-handler": "3.342.0",
+        "@aws-sdk/hash-blob-browser": "3.342.0",
+        "@aws-sdk/hash-node": "3.344.0",
+        "@aws-sdk/hash-stream-node": "3.342.0",
+        "@aws-sdk/invalid-dependency": "3.342.0",
+        "@aws-sdk/md5-js": "3.342.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.342.0",
+        "@aws-sdk/middleware-content-length": "3.342.0",
+        "@aws-sdk/middleware-endpoint": "3.344.0",
+        "@aws-sdk/middleware-expect-continue": "3.342.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.342.0",
+        "@aws-sdk/middleware-host-header": "3.342.0",
+        "@aws-sdk/middleware-location-constraint": "3.342.0",
+        "@aws-sdk/middleware-logger": "3.342.0",
+        "@aws-sdk/middleware-recursion-detection": "3.342.0",
+        "@aws-sdk/middleware-retry": "3.342.0",
+        "@aws-sdk/middleware-sdk-s3": "3.342.0",
+        "@aws-sdk/middleware-serde": "3.342.0",
+        "@aws-sdk/middleware-signing": "3.342.0",
+        "@aws-sdk/middleware-ssec": "3.342.0",
+        "@aws-sdk/middleware-stack": "3.342.0",
+        "@aws-sdk/middleware-user-agent": "3.345.0",
+        "@aws-sdk/node-config-provider": "3.342.0",
+        "@aws-sdk/node-http-handler": "3.344.0",
+        "@aws-sdk/signature-v4-multi-region": "3.344.0",
+        "@aws-sdk/smithy-client": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/url-parser": "3.342.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.342.0",
+        "@aws-sdk/util-defaults-mode-node": "3.342.0",
+        "@aws-sdk/util-endpoints": "3.342.0",
+        "@aws-sdk/util-retry": "3.342.0",
+        "@aws-sdk/util-stream-browser": "3.342.0",
+        "@aws-sdk/util-stream-node": "3.344.0",
+        "@aws-sdk/util-user-agent-browser": "3.345.0",
+        "@aws-sdk/util-user-agent-node": "3.345.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@aws-sdk/util-waiter": "3.342.0",
+        "@aws-sdk/xml-builder": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "fast-xml-parser": "4.1.2",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.58.0.tgz",
-      "integrity": "sha512-nS5G/OX8Bg4ajBa6+jLcbbr4PpEO+l5eJfGUzoJQwS4Zqa0lF/wC0kyjKm61gLp4JuvhrQskxIC/3IXUqB1XVQ==",
+      "version": "3.345.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.345.0.tgz",
+      "integrity": "sha512-HZNz2AVK+4o149HlIPnVc0CQ7MqsaPqrDiCUBCSHH/wKFVTFMas/cbxx9zLq+pfUD+8p4eSYpd9fv8eHgZOZsg==",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.58.0",
-        "@aws-sdk/fetch-http-handler": "3.58.0",
-        "@aws-sdk/hash-node": "3.55.0",
-        "@aws-sdk/invalid-dependency": "3.55.0",
-        "@aws-sdk/middleware-content-length": "3.58.0",
-        "@aws-sdk/middleware-host-header": "3.58.0",
-        "@aws-sdk/middleware-logger": "3.55.0",
-        "@aws-sdk/middleware-retry": "3.58.0",
-        "@aws-sdk/middleware-serde": "3.55.0",
-        "@aws-sdk/middleware-stack": "3.55.0",
-        "@aws-sdk/middleware-user-agent": "3.58.0",
-        "@aws-sdk/node-config-provider": "3.58.0",
-        "@aws-sdk/node-http-handler": "3.58.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/smithy-client": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/url-parser": "3.55.0",
-        "@aws-sdk/util-base64-browser": "3.58.0",
-        "@aws-sdk/util-base64-node": "3.55.0",
-        "@aws-sdk/util-body-length-browser": "3.55.0",
-        "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.55.0",
-        "@aws-sdk/util-defaults-mode-node": "3.58.0",
-        "@aws-sdk/util-user-agent-browser": "3.58.0",
-        "@aws-sdk/util-user-agent-node": "3.58.0",
-        "@aws-sdk/util-utf8-browser": "3.55.0",
-        "@aws-sdk/util-utf8-node": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.342.0",
+        "@aws-sdk/fetch-http-handler": "3.342.0",
+        "@aws-sdk/hash-node": "3.344.0",
+        "@aws-sdk/invalid-dependency": "3.342.0",
+        "@aws-sdk/middleware-content-length": "3.342.0",
+        "@aws-sdk/middleware-endpoint": "3.344.0",
+        "@aws-sdk/middleware-host-header": "3.342.0",
+        "@aws-sdk/middleware-logger": "3.342.0",
+        "@aws-sdk/middleware-recursion-detection": "3.342.0",
+        "@aws-sdk/middleware-retry": "3.342.0",
+        "@aws-sdk/middleware-serde": "3.342.0",
+        "@aws-sdk/middleware-stack": "3.342.0",
+        "@aws-sdk/middleware-user-agent": "3.345.0",
+        "@aws-sdk/node-config-provider": "3.342.0",
+        "@aws-sdk/node-http-handler": "3.344.0",
+        "@aws-sdk/smithy-client": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/url-parser": "3.342.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.342.0",
+        "@aws-sdk/util-defaults-mode-node": "3.342.0",
+        "@aws-sdk/util-endpoints": "3.342.0",
+        "@aws-sdk/util-retry": "3.342.0",
+        "@aws-sdk/util-user-agent-browser": "3.345.0",
+        "@aws-sdk/util-user-agent-node": "3.345.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.345.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.345.0.tgz",
+      "integrity": "sha512-vKF1Gl/04smhloujzPu+cud63jxgU3lsV+lt9J4HHOmsvTpfuTR/jSG88hfBM6Esmnzpz56u9qi7AZ5nlmSsgQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.342.0",
+        "@aws-sdk/fetch-http-handler": "3.342.0",
+        "@aws-sdk/hash-node": "3.344.0",
+        "@aws-sdk/invalid-dependency": "3.342.0",
+        "@aws-sdk/middleware-content-length": "3.342.0",
+        "@aws-sdk/middleware-endpoint": "3.344.0",
+        "@aws-sdk/middleware-host-header": "3.342.0",
+        "@aws-sdk/middleware-logger": "3.342.0",
+        "@aws-sdk/middleware-recursion-detection": "3.342.0",
+        "@aws-sdk/middleware-retry": "3.342.0",
+        "@aws-sdk/middleware-serde": "3.342.0",
+        "@aws-sdk/middleware-stack": "3.342.0",
+        "@aws-sdk/middleware-user-agent": "3.345.0",
+        "@aws-sdk/node-config-provider": "3.342.0",
+        "@aws-sdk/node-http-handler": "3.344.0",
+        "@aws-sdk/smithy-client": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/url-parser": "3.342.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.342.0",
+        "@aws-sdk/util-defaults-mode-node": "3.342.0",
+        "@aws-sdk/util-endpoints": "3.342.0",
+        "@aws-sdk/util-retry": "3.342.0",
+        "@aws-sdk/util-user-agent-browser": "3.345.0",
+        "@aws-sdk/util-user-agent-node": "3.345.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.58.0.tgz",
-      "integrity": "sha512-2cHZsG2eXv/Zl0hvsG9+rdHEuAclMFfkma/3LC3RRwSuZXo1rXoIhFkzHfGfIbivdk738YAo7FT3ZYGlrsK4ow==",
+      "version": "3.345.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.345.0.tgz",
+      "integrity": "sha512-OCnwqTegZr+HHkiVUlOEiKBDE03DDVOXGKM/GTRA9mOic5bukh4z1TwSZOgoqxhpix4fX8xE4sdp9408mcfWEQ==",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.58.0",
-        "@aws-sdk/credential-provider-node": "3.58.0",
-        "@aws-sdk/fetch-http-handler": "3.58.0",
-        "@aws-sdk/hash-node": "3.55.0",
-        "@aws-sdk/invalid-dependency": "3.55.0",
-        "@aws-sdk/middleware-content-length": "3.58.0",
-        "@aws-sdk/middleware-host-header": "3.58.0",
-        "@aws-sdk/middleware-logger": "3.55.0",
-        "@aws-sdk/middleware-retry": "3.58.0",
-        "@aws-sdk/middleware-sdk-sts": "3.58.0",
-        "@aws-sdk/middleware-serde": "3.55.0",
-        "@aws-sdk/middleware-signing": "3.58.0",
-        "@aws-sdk/middleware-stack": "3.55.0",
-        "@aws-sdk/middleware-user-agent": "3.58.0",
-        "@aws-sdk/node-config-provider": "3.58.0",
-        "@aws-sdk/node-http-handler": "3.58.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/smithy-client": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/url-parser": "3.55.0",
-        "@aws-sdk/util-base64-browser": "3.58.0",
-        "@aws-sdk/util-base64-node": "3.55.0",
-        "@aws-sdk/util-body-length-browser": "3.55.0",
-        "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.55.0",
-        "@aws-sdk/util-defaults-mode-node": "3.58.0",
-        "@aws-sdk/util-user-agent-browser": "3.58.0",
-        "@aws-sdk/util-user-agent-node": "3.58.0",
-        "@aws-sdk/util-utf8-browser": "3.55.0",
-        "@aws-sdk/util-utf8-node": "3.55.0",
-        "entities": "2.2.0",
-        "fast-xml-parser": "3.19.0",
-        "tslib": "^2.3.1"
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.342.0",
+        "@aws-sdk/credential-provider-node": "3.345.0",
+        "@aws-sdk/fetch-http-handler": "3.342.0",
+        "@aws-sdk/hash-node": "3.344.0",
+        "@aws-sdk/invalid-dependency": "3.342.0",
+        "@aws-sdk/middleware-content-length": "3.342.0",
+        "@aws-sdk/middleware-endpoint": "3.344.0",
+        "@aws-sdk/middleware-host-header": "3.342.0",
+        "@aws-sdk/middleware-logger": "3.342.0",
+        "@aws-sdk/middleware-recursion-detection": "3.342.0",
+        "@aws-sdk/middleware-retry": "3.342.0",
+        "@aws-sdk/middleware-sdk-sts": "3.342.0",
+        "@aws-sdk/middleware-serde": "3.342.0",
+        "@aws-sdk/middleware-signing": "3.342.0",
+        "@aws-sdk/middleware-stack": "3.342.0",
+        "@aws-sdk/middleware-user-agent": "3.345.0",
+        "@aws-sdk/node-config-provider": "3.342.0",
+        "@aws-sdk/node-http-handler": "3.344.0",
+        "@aws-sdk/smithy-client": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/url-parser": "3.342.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-body-length-browser": "3.310.0",
+        "@aws-sdk/util-body-length-node": "3.310.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.342.0",
+        "@aws-sdk/util-defaults-mode-node": "3.342.0",
+        "@aws-sdk/util-endpoints": "3.342.0",
+        "@aws-sdk/util-retry": "3.342.0",
+        "@aws-sdk/util-user-agent-browser": "3.345.0",
+        "@aws-sdk/util-user-agent-node": "3.345.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "@smithy/protocol-http": "^1.0.1",
+        "@smithy/types": "^1.0.0",
+        "fast-xml-parser": "4.1.2",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.58.0.tgz",
-      "integrity": "sha512-NXEwYw0JrXcvenu42QpNMQXK+6pgZ+6bDGfCgOfCC0FmyI+w/CuF36lApwm7InHvHazOaDlwArXm2pfntErKoA==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.342.0.tgz",
+      "integrity": "sha512-jUg6DTTrCvG8AOPv5NRJ6PSQSC5fEI2gVv4luzvrGkRJULYbIqpdfUYdW7jB3rWAWC79pQQr5lSqC5DWH91stw==",
       "dependencies": {
-        "@aws-sdk/signature-v4": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/util-config-provider": "3.55.0",
-        "@aws-sdk/util-middleware": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/util-config-provider": "3.310.0",
+        "@aws-sdk/util-middleware": "3.342.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.55.0.tgz",
-      "integrity": "sha512-4AIIXEdvinLlWNFtrUbUgoB7dkuV04RTcTruVWI4Ub4WSsuSCa72ZU1vqyvcEAOgGGLBmcSaGTWByjiD2sGcGA==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.342.0.tgz",
+      "integrity": "sha512-mufOcoqdXZXkvA7u6hUcJz6wKpVaho8SRWCvJrGO4YkyudUAoI9KSP5R4U+gtneDJ2Y/IEKPuw8ugNfANa1J+A==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.58.0.tgz",
-      "integrity": "sha512-CdtnTQ9zqLx1FbXdbgjijLbMcIWOyQM03TFaLSCjI3FNbUwyt3T7StBU9tj/LtbypHhSdXyQBpzUtXTOMWCEhg==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.342.0.tgz",
+      "integrity": "sha512-ReaHwFLfcsEYjDFvi95OFd+IU8frPwuAygwL56aiMT7Voc0oy3EqB3MFs3gzFxdLsJ0vw9TZMRbaouepAEVCkA==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.58.0",
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/url-parser": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/node-config-provider": "3.342.0",
+        "@aws-sdk/property-provider": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/url-parser": "3.342.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.58.0.tgz",
-      "integrity": "sha512-uM62hcHUVaHP1YFnbrjf2RlrRj1m/BvMPE+T5jdNRWdE3lvnunhEMawB26HZs9nQqCV6d25I8G9/fGWVL7g3Og==",
+      "version": "3.345.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.345.0.tgz",
+      "integrity": "sha512-3uT4JXNaFjOIZSMOxOGzhoO6fINyoIxcLK7F1wtEesmD2Ddp8y7DANbBR8alkfirSbTanZK0CuK5PXDn+4GGYQ==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.55.0",
-        "@aws-sdk/credential-provider-imds": "3.58.0",
-        "@aws-sdk/credential-provider-sso": "3.58.0",
-        "@aws-sdk/credential-provider-web-identity": "3.55.0",
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/shared-ini-file-loader": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/credential-provider-env": "3.342.0",
+        "@aws-sdk/credential-provider-imds": "3.342.0",
+        "@aws-sdk/credential-provider-process": "3.342.0",
+        "@aws-sdk/credential-provider-sso": "3.345.0",
+        "@aws-sdk/credential-provider-web-identity": "3.342.0",
+        "@aws-sdk/property-provider": "3.342.0",
+        "@aws-sdk/shared-ini-file-loader": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.58.0.tgz",
-      "integrity": "sha512-f0wzcgMYCQUrii6TLP2ggCxkQP4HH8PW8tbbWEgt4cdIXcjE9KEuxN5yOV6sFHzL3eJh0QM9Yaz8WzhWn6fT2A==",
+      "version": "3.345.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.345.0.tgz",
+      "integrity": "sha512-aNuEH3qFFGIrtRkmH2Py65xIQBFkqxZjjY+/XlQcAxmKTDjqb6CB6jvdA7K53GC7z8KGjOuK5d7TZCGW8ufxpg==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.55.0",
-        "@aws-sdk/credential-provider-imds": "3.58.0",
-        "@aws-sdk/credential-provider-ini": "3.58.0",
-        "@aws-sdk/credential-provider-process": "3.58.0",
-        "@aws-sdk/credential-provider-sso": "3.58.0",
-        "@aws-sdk/credential-provider-web-identity": "3.55.0",
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/shared-ini-file-loader": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/credential-provider-env": "3.342.0",
+        "@aws-sdk/credential-provider-imds": "3.342.0",
+        "@aws-sdk/credential-provider-ini": "3.345.0",
+        "@aws-sdk/credential-provider-process": "3.342.0",
+        "@aws-sdk/credential-provider-sso": "3.345.0",
+        "@aws-sdk/credential-provider-web-identity": "3.342.0",
+        "@aws-sdk/property-provider": "3.342.0",
+        "@aws-sdk/shared-ini-file-loader": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.58.0.tgz",
-      "integrity": "sha512-npgFqPUjMhUamf1FvJjBYUdpbWx8XWkKCwJsX73I7IYQAvAi2atCOkdtKq+4rds0VWAYu6vzlaI1tXgFxjOPNQ==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.342.0.tgz",
+      "integrity": "sha512-q03yJQPa4jnZtwKFW3yEYNMcpYH7wQzbEOEXjnXG4v8935oOttZjXBvRK7ax+f0D1ZHZFeFSashjw0A/bi1efQ==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/shared-ini-file-loader": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.342.0",
+        "@aws-sdk/shared-ini-file-loader": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.58.0.tgz",
-      "integrity": "sha512-2qO34s9lJqvCC6zOF4UpopW6xURZpYfVC8xTUDpAUnvTOt4nS5hkx4vNyqPAXILoRHuFJsnlWsBH1UP5ZnBiZg==",
+      "version": "3.345.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.345.0.tgz",
+      "integrity": "sha512-SOcLWdLG/jv9L/X1Kx7G7Ma1Tojk3+vJ6oSKTjrRk5Y+7uErW5qfcOZ4vSjY8by3OCywJcg6jXHK4jDjJwfw1A==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.58.0",
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/shared-ini-file-loader": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/client-sso": "3.345.0",
+        "@aws-sdk/property-provider": "3.342.0",
+        "@aws-sdk/shared-ini-file-loader": "3.342.0",
+        "@aws-sdk/token-providers": "3.345.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.55.0.tgz",
-      "integrity": "sha512-aKnXfZNGohTuF9rCGYLg4JEIOvWIZ/sb66XMq7bOUrx13KRPDwL/eUQL8quS5jGRLpjXVNvrS17AFf65GbdUBg==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.342.0.tgz",
+      "integrity": "sha512-+an5oGnzoXMmGJql0Qs9MtyQTmz5GFqrWleQ0k9UVhN3uIfCS9AITS7vb+q1+G7A7YXy9+KshgBhcHco0G/JWQ==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/property-provider": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/eventstream-marshaller": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.58.0.tgz",
-      "integrity": "sha512-vTdVFLIHGZTx/Anp9GpkTXVuvwSCNOecTutU5Py4i6fATgefWiSutc5Xc/FLujBSc0EhAXDGZIcTMpZC7jUpeg==",
+    "node_modules/@aws-sdk/eventstream-codec": {
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.342.0.tgz",
+      "integrity": "sha512-IwtvSuplioMyiu/pQgpazKkGWDM5M5BOx85zmsB0uNxt6rmje8+WqPmGmuPdmJv4bLC5dJPLovcCp/fuH8XWhA==",
       "dependencies": {
-        "@aws-crypto/crc32": "2.0.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/util-hex-encoding": "3.58.0",
-        "tslib": "^2.3.1"
+        "@aws-crypto/crc32": "3.0.0",
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/eventstream-serde-browser": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.58.0.tgz",
-      "integrity": "sha512-oR5yoOoJrTSUKwbxZSt37bZgMXUUSsOub96E6SOb8wh8TMq2f0wvqeO8A+aaxY487gKpzuVUClp7jSQ9LgiVcw==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.342.0.tgz",
+      "integrity": "sha512-IP+bbq6NRENuWong/PZdLcJo6Pv3tElrQOxD+XEQw4IIdFsSmHAoGGrQtMsGlPHAnEAM0KOTZDOeP/SdB+tKUw==",
       "dependencies": {
-        "@aws-sdk/eventstream-marshaller": "3.58.0",
-        "@aws-sdk/eventstream-serde-universal": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/eventstream-serde-universal": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/eventstream-serde-config-resolver": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.55.0.tgz",
-      "integrity": "sha512-NTJHLq1sbXyXAaJucKvcdN3Svr/fM2TjHEC3l8P/torFjIsX1+Ykpi8tZt8KsX8RjoUTTfKylh41AjJq0K9X4Q==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.342.0.tgz",
+      "integrity": "sha512-sV4aqEk6JTm9LzTWH6oNlLzQM+560903VFFL05xTq0LHB5946T4rqCz+2Hg56wQJ5oII6EgzWuY8mieW/hUhew==",
       "dependencies": {
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/eventstream-serde-node": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.58.0.tgz",
-      "integrity": "sha512-U1DnRVfvKOXty+Bei6oqhRWFzGWzxl0OFHtev9GzC7BE/E6s4Gn695o+NO+9IwQgjOlc/JsGyAcWevq3MDxymg==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.342.0.tgz",
+      "integrity": "sha512-96KPMIJNZRHuMtaSH9wXuqakkWjT+z4KSnrycnnb4TgBqhenSU2qPEjVcseoCeJxls5mgYQOCQx65KV/ia46wA==",
       "dependencies": {
-        "@aws-sdk/eventstream-marshaller": "3.58.0",
-        "@aws-sdk/eventstream-serde-universal": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/eventstream-serde-universal": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/eventstream-serde-universal": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.58.0.tgz",
-      "integrity": "sha512-w7czmMNvCCspJi8Ij0lTByCiuYBhyNzYTM1wv33vtF7dL+FJgi4W4c5WFAOtvpsPulobY013TWCjPJG+V0IPGQ==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.342.0.tgz",
+      "integrity": "sha512-B7sJu/GIEt1Bkvwt1I1oimYxM4CSA9DBA6PnNSbqD8BaCd+w8Rxcb35n6IohmfzLSbZxeI81p9XVD2q7BIY0Wg==",
       "dependencies": {
-        "@aws-sdk/eventstream-marshaller": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/eventstream-codec": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.58.0.tgz",
-      "integrity": "sha512-timF3FjPV5Bd+Kgph83LIKVlPCFObVYzious1a6doeLAT6YFwZpRrWbfP/HzS+DCoYiwUsH69oVJ91BoV66oyA==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.342.0.tgz",
+      "integrity": "sha512-zsC23VUQMHEu4OKloLCVyWLG0ns6n+HKZ9euGLnNO3l0VSRne9qj/94yR+4jr/h04M7MhGf9mlczGfnZUFxs5w==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/querystring-builder": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/util-base64-browser": "3.58.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.342.0",
+        "@aws-sdk/querystring-builder": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/hash-blob-browser": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.58.0.tgz",
-      "integrity": "sha512-fdp12BqypRxwvevbJSl/sUhXJRi4Ghv6JKEXAHI1klkR6xY1GRORO5SHWltVY/xl373ERMol5o/n+ra/7jcx/g==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.342.0.tgz",
+      "integrity": "sha512-fdCmHcFltKvp5TkYB4Qv9E1N98pc/mmWsFld7sQUomlr44Sdokf04QleYLjAPo9knX0P0moKuYlDHBuECaRNbw==",
       "dependencies": {
-        "@aws-sdk/chunked-blob-reader": "3.55.0",
-        "@aws-sdk/chunked-blob-reader-native": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/chunked-blob-reader": "3.310.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/hash-node": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.55.0.tgz",
-      "integrity": "sha512-2UdYwY/++AlzWEAFaK9wOed2QSxbzV527vmqKjReLHpPKPrSIlooUxlTH3LU6Y6WVDAzDRtLK43KUVXTLgGK1A==",
+      "version": "3.344.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.344.0.tgz",
+      "integrity": "sha512-K0/mSvYR4hEfTRnnyoTj8ccqbXe2PpwvP4u8GXwk3Nr7s8qhDPYe8tFMv+6hoDJ50WJHrMTYGZ1HDAmjvP9uhA==",
       "dependencies": {
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/util-buffer-from": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/hash-stream-node": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.58.0.tgz",
-      "integrity": "sha512-y7HEeC3OiuXCRqsHnKDn5yef8UAbnegD9r+OM9bdD+3e6FLAL8Rq7hQTOpwIAiPXuD7HKx8h98s9JLvkwTOBkg==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.342.0.tgz",
+      "integrity": "sha512-8Ih3499SinJnuPAu1M7SBP5kF9zR8OsqD02VW8bO9jBpu1AYzs5k2OxTb86R+OWS6H+PJP6v1eTxNc9ZKUOhjg==",
       "dependencies": {
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.55.0.tgz",
-      "integrity": "sha512-delH0lV+78fdD/8MXIt9kTLS6IwHvdhqq9dw/ow5VjTUw+xBwUlfPfZplaai+3hKTKWh6a2WZCeDasNItBv9aA==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.342.0.tgz",
+      "integrity": "sha512-3qza2Br1jGKJi8toPYG9u5aGJ3sbGmJLgKDvlga7q3F8JaeB92He6muRJ07eyDvxZ9jiKhLZ2mtYoVcEjI7Mgw==",
       "dependencies": {
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.55.0.tgz",
-      "integrity": "sha512-NbiPHVYuPxdqdFd6FxzzN3H1BQn/iWA3ri3Ry7AyLeP/tGs1yzEWMwf8BN8TSMALI0GXT6Sh0GDWy3Ok5xB6DA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.310.0.tgz",
+      "integrity": "sha512-urnbcCR+h9NWUnmOtet/s4ghvzsidFmspfhYaHAmSRdy9yDjdjBJMFjjsn85A1ODUktztm+cVncXjQ38WCMjMQ==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/md5-js": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.58.0.tgz",
-      "integrity": "sha512-V5f4Re+CLn3aDF1nrmDqdUtcqBHCyxxD2s2Ot+hZ2JFit+OtJggo1cI03ldTrQpG79rwHG+bHqL2VvNQP7Aj9A==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.342.0.tgz",
+      "integrity": "sha512-wtuvAgxz0DWfbXZyqzdkEXGYY1esEbgmjMj8gAoqomvbmiThOEisxNvHcCUJwgqs6vlPNP5pGBtgoHGF5J7JWA==",
       "dependencies": {
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/util-utf8-browser": "3.55.0",
-        "@aws-sdk/util-utf8-node": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.58.0.tgz",
-      "integrity": "sha512-zocLfFzj+NQjXLGZKPJBAYWWldAKBJkGzGVpTfrYx9bxxHTA70Gu+3sx+Xe+iOu8dtQT0OAnIX0wGudOPnTGNg==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.342.0.tgz",
+      "integrity": "sha512-o6DNAmAt1MtCeg/mekcpIw/3Bcr9PAJM0Ogv3GUar2J8ziUDtaRGO0zm0YrQjsZf7E5+JLWMFL+OAeYeVV6QwA==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/util-arn-parser": "3.55.0",
-        "@aws-sdk/util-config-provider": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/util-arn-parser": "3.310.0",
+        "@aws-sdk/util-config-provider": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.58.0.tgz",
-      "integrity": "sha512-h/BypPkhjv2CpCUbXA8Fa2s7V2GPiz9l11XhYK+sKSuQvQ7Lbq6VhaKaLqfeD3gLVZHgJZSLGl2btdHV1qHNNA==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.342.0.tgz",
+      "integrity": "sha512-7LUMZqhihSAptGRFFQvuwt9nCLNzNPkGd1oU1RpVXw6YPQfKP9Ec5tgg4oUlv1t58IYQvdVj5ITKp4X2aUJVPg==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.344.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.344.0.tgz",
+      "integrity": "sha512-rg4ysfusGw5tm8XTqNpdWo0wP0K79hZs3z1xkkskeSsMrbYiDn78Bkkt4s3JELUJY64VanQktPaKo08dNFYNZw==",
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/url-parser": "3.342.0",
+        "@aws-sdk/util-middleware": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.58.0.tgz",
-      "integrity": "sha512-nx6X6qLPwvbJrGoPxXSu4tsOek2eRnnjk78hhRUDfxFewpHJQLSPlyNKkXAo+C3syVALe6RJRmUYu5bShY6FfA==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.342.0.tgz",
+      "integrity": "sha512-ohSZfseSJGECogtaXS/9VntGBALkJhfpsI7sK3cC20XcBlTI55rpy1AmD4vy0BEjEUQYBrkGuKKdmlT8DnjDRA==",
       "dependencies": {
-        "@aws-sdk/middleware-header-default": "3.58.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.58.0.tgz",
-      "integrity": "sha512-R8S3U1boaIb7+kYhLJBks7rv/eaGj7I5T/2CgmcGY1BJBUU0h0arjPC7eeA/5wV29EHapoxVYQvJda//706rCw==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.342.0.tgz",
+      "integrity": "sha512-D68clBx5IHILCe4u8zxr0YRUHmQR6wf6pmLC9ddw7qWMgUU3Nr7AzzWebFO+VkoS5rX3KqQ0xCwzBUtYvixaNQ==",
       "dependencies": {
-        "@aws-crypto/crc32": "2.0.0",
-        "@aws-crypto/crc32c": "2.0.0",
-        "@aws-sdk/is-array-buffer": "3.55.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-crypto/crc32": "3.0.0",
+        "@aws-crypto/crc32c": "3.0.0",
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "@aws-sdk/protocol-http": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-header-default": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.58.0.tgz",
-      "integrity": "sha512-7F+CdLLauMmNbwFGYrE2pKsgTKY8G2PgazHmaE9s3FySEFcGPWmiEAG8sVImfZooj8gxGFQMLr97nanWjhSq2Q==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.58.0.tgz",
-      "integrity": "sha512-q/UKGcanm9e6DBRNN6UKhVqLvpRRdZWbmmPCeDNr4HqhCmgT6i1OvWdhAMOnT++hvCX8DpTsIXzNSlY6zWAxBg==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.342.0.tgz",
+      "integrity": "sha512-EOoix2D2Mk3NQtv7UVhJttfttGYechQxKuGvCI8+8iEKxqlyXaKqAkLR07BQb6epMYeKP4z1PfJm203Sf0WPUQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.55.0.tgz",
-      "integrity": "sha512-OvCKwBFbl8Gbfk0HGX00pkdORJN8BPuH/O5l3+mOBWuwILPuckRP5WGnL+1HT/gu4hHS6h1lpxUrPxUOoeKIAg==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.342.0.tgz",
+      "integrity": "sha512-lakeKpMZreCc1nVTkVfkdl5SuojfKNL2oJvXVDDUFJ91sYx9FmhAT3++kWAun2SrU2S4TNXJ2SQL/8ON8TtSYQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.55.0.tgz",
-      "integrity": "sha512-PtRbVrxEzDmeV9prBIP4/9or7R5Dj66mjbFSvNRGZ0n+UBfBFfVRfNrhQPNzQpfV9A3KVl9YyWCVXDSW+/rk9Q==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.342.0.tgz",
+      "integrity": "sha512-wbkp85T7p9sHLNPMY6HAXHvLOp+vOubFT/XLIGtgRhYu5aRJSlVo9qlwtdZjyhEgIRQ6H/QUnqAN7Zgk5bCLSw==",
       "dependencies": {
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.342.0.tgz",
+      "integrity": "sha512-KUDseSAz95kXCqnXEQxNObpviZ6F7eJ5lEgpi+ZehlzGDk/GyOVgjVuAyI7nNxWI5v0ZJ5nIDy+BH273dWbnmQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.58.0.tgz",
-      "integrity": "sha512-sfSq+t0Yy47DQwrWGpA8iOx9sd26l4l1JDVTwHNi7+OKD4ClRPVCEdw3bTbbyYz/PV4f9AEfAZ6jwtSff4wkGw==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.342.0.tgz",
+      "integrity": "sha512-Bfllrjqs0bXNG7A3ydLjTAE5zPEdigG+/lDuEsCfB35gywZnnxqi6BjTeQ9Ss6gbEWX+WyXP7/oVdNaUDQUr9Q==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/service-error-classification": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/util-middleware": "3.55.0",
-        "tslib": "^2.3.1",
+        "@aws-sdk/protocol-http": "3.342.0",
+        "@aws-sdk/service-error-classification": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/util-middleware": "3.342.0",
+        "@aws-sdk/util-retry": "3.342.0",
+        "tslib": "^2.5.0",
         "uuid": "^8.3.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.58.0.tgz",
-      "integrity": "sha512-vOTPOdhZpNJo4v54evg6JnFz14hK8IW2u8B+12iV5ZQ4zJom6VowzFmIOUn+KIsw/6SrwEX9tFb0aXLlVRw27Q==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.342.0.tgz",
+      "integrity": "sha512-fGZBmeSvOLKo4k/CSoa2v2TNdbw6eszGaFekOqHrIyfTW/a+VTcz+/MBLF9Cq1gayF1udjqjS+qbKB2ZiR31tA==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/signature-v4": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/util-arn-parser": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/protocol-http": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/util-arn-parser": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.342.0.tgz",
+      "integrity": "sha512-eGcGDC+6UWKC87mex3voBVRcZN3hzFN6GVzWkTS574hDqp/uJG3yPk3Dltw0qf8skikTGi3/ZE+yAxerq/f5rg==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.342.0.tgz",
+      "integrity": "sha512-WRD+Cyu6+h1ymfPnAw4fI2q3zXjihJ55HFe1uRF8VPN4uBbJNfN3IqL38y/SMEdZ0gH9zNlRNxZLhR0q6SNZEQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.342.0.tgz",
+      "integrity": "sha512-CFRQyPv4OjRGmFoB3OfKcQ0aHgS9VWC0YwoHnSWIcLt3Xltorug/Amk0obr/MFoIrktdlVtmvLEJ4Z+8cdsz8g==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.342.0",
+        "@aws-sdk/protocol-http": "3.342.0",
+        "@aws-sdk/signature-v4": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/util-middleware": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.342.0.tgz",
+      "integrity": "sha512-KLyxh082ITudpzlwtIEIq7VfBGpz/BdFafJOnO5h3TwJcIPsCml7XqLzbrjej8cPINRIqnXwMw8Pow/jC6drDg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.342.0.tgz",
+      "integrity": "sha512-nDYtLAv9IZq8YFxtbyAiK/U1mtvtJS0DG6HiIPT5jpHcRpuWRHQ170EAW51zYts+21Ffj1VA6ZPkbup83+T6/w==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.345.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.345.0.tgz",
+      "integrity": "sha512-e3auH6sqwyKCXCFNwRWYKkvWWxDHhyEnVWoYJEHqDwG6iWRwKqTBigIHao0sIrSEtZlewtE5pdeuTb0xoY19ZA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/util-endpoints": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.342.0.tgz",
+      "integrity": "sha512-Mwkj4+zt64w7a8QDrI9q4SrEt7XRO30Vk0a0xENqcOGrKIPfF5aeqlw85NYLoGys+KV1oatqQ+k0GzKx8qTIdQ==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.342.0",
+        "@aws-sdk/shared-ini-file-loader": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.344.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.344.0.tgz",
+      "integrity": "sha512-04o5rrFBd8VzzN0Pcs7EEsyC6dz1maILbA6vdXrDvVLYqaO40Tpx2E/3KA/jZtOpHcGXxgDw2rv1kjJesoiEMw==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.342.0",
+        "@aws-sdk/protocol-http": "3.342.0",
+        "@aws-sdk/querystring-builder": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/property-provider": {
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.342.0.tgz",
+      "integrity": "sha512-p4TR9yRakIpwupEH3BUijWMYThGG0q43n1ICcsBOcvWZpE636lIUw6nzFlOuBUwqyPfUyLbXzchvosYxfCl0jw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http": {
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.342.0.tgz",
+      "integrity": "sha512-zuF2urcTJBZ1tltPdTBQzRasuGB7+4Yfs9i5l0F7lE0luK5Azy6G+2r3WWENUNxFTYuP94GrrqaOhVyj8XXLPQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.342.0.tgz",
+      "integrity": "sha512-tb3FbtC36a7XBYeupdKm60LeM0etp73I6/7pDAkzAlw7zJdvY0aQIvj1c0U6nZlwZF8sSSxC7vlamR+wCspdMw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.342.0.tgz",
+      "integrity": "sha512-6svvr/LZW1EPJaARnOpjf92FIiK25wuO7fRq05gLTcTRAfUMDvub+oDg3Ro9EjJERumrYQrYCem5Qi4X9w8K2g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.342.0.tgz",
+      "integrity": "sha512-MwHO5McbdAVKxfQj1yhleboAXqrzcGoi9ODS+bwCwRfe2lakGzBBhu8zaGDlKYOdv5rS+yAPP/5fZZUiuZY8Bw==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.342.0.tgz",
+      "integrity": "sha512-kQG7TMQMhNp5+Y8vhGuO/+wU3K/dTx0xC0AKoDFiBf6EpDRmDfr2pPRnfJ9GwgS9haHxJ/3Uwc03swHMlsj20A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4": {
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.342.0.tgz",
+      "integrity": "sha512-OWrGO2UOa1ENpy0kYd2shK4sklQygWUqvWLx9FotDbjIeUIEfAnqoPq/QqcXVrNyT/UvPi4iIrjHJEO8JCNRmA==",
+      "dependencies": {
+        "@aws-sdk/eventstream-codec": "3.342.0",
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-middleware": "3.342.0",
+        "@aws-sdk/util-uri-escape": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.344.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.344.0.tgz",
+      "integrity": "sha512-B5hN9b0Qa3UvpzsLjGIeCZ9AXE1qpwSXNXEeGcAdUIyf6lG3l+JMREKr+ZVaqAwAcZCOWmUyuuHIhkiK5YzClg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.342.0",
+        "@aws-sdk/signature-v4": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/signature-v4-crt": "^3.54.1"
+        "@aws-sdk/signature-v4-crt": "^3.118.0"
       },
       "peerDependenciesMeta": {
         "@aws-sdk/signature-v4-crt": {
@@ -782,513 +1065,424 @@
         }
       }
     },
-    "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.58.0.tgz",
-      "integrity": "sha512-HUz7MhcsSDDTGygOwL61l4voc0pZco06J3z06JjTX19D5XxcQ7hSCtkHHHz0oMb9M1himVSiEon2tjhjsnB99g==",
-      "dependencies": {
-        "@aws-sdk/middleware-signing": "3.58.0",
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/signature-v4": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.55.0.tgz",
-      "integrity": "sha512-NkEbTDrSZcC2NhuvfjXHKJEl0xgI2B5tMAwi/rMOq/TEnARwVUL9qAy+5lgeiPCqebiNllWatARrFgAaYf0VeA==",
-      "dependencies": {
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.58.0.tgz",
-      "integrity": "sha512-4FXubHB66GbhyZUlo6YPQoWpYfED15GNbEmHbJLSONzrVzZR3IkViSPLasDngVm1a050JqKuqNkFYGJBP4No/Q==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/signature-v4": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.55.0.tgz",
-      "integrity": "sha512-HTdA23hksOphQe0TmYORsa/kMNnKRGbdh0VJcsDGHQScJXzJ+C//THwfcoklff0XZfC+vGh93PECBWqixMELZw==",
-      "dependencies": {
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.55.0.tgz",
-      "integrity": "sha512-ouD+wFz8W2R0ZQ8HrbhgN8tg1jyINEg9lPEEXY79w1Q5sf94LJ90XKAMVk02rw3dJalUWjLHf0OQe1/qxZfHyA==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.58.0.tgz",
-      "integrity": "sha512-1c69bIWM63JwXijXvb9IWwcwQ/gViKMZ1lhxv52NvdG5VSxWXXsFJ2jETEXZoAypwT97Hmf3xo9SYuaHcKoq+g==",
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.58.0.tgz",
-      "integrity": "sha512-AMcPqPhKxo/3/yOMS9PsKlI0GWp2/8eD6gSlhzdBpznPCKplyqXOSnSX7wS814Cyh373hFSjCaOrCOA9/EYtDg==",
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/shared-ini-file-loader": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.58.0.tgz",
-      "integrity": "sha512-D9xVZG2nfo4GbPsby3JuBiAhpqXTFk1+CfuQU0AZv0gQvE3fFTCnB3za83jo7JV/pyRPU+s+/LHIpxCWUHzStg==",
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.55.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/querystring-builder": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/property-provider": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.55.0.tgz",
-      "integrity": "sha512-o7cKFJSHq5WOhwPsspYrzNto35oKKZvESZuWDtLxaZKSI6l7zpA366BI4kDG6Tc9i2+teV553MbxyZ9eya5A8g==",
-      "dependencies": {
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.58.0.tgz",
-      "integrity": "sha512-0yFFRPbR+CCa9eOQBBQ2qtrIDLYqSMN0y7G4iqVM8wQdIw7n3QK1PsTI3RNPGJ3Oi2krFTw5uUKqQQZPZEBuVQ==",
-      "dependencies": {
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.55.0.tgz",
-      "integrity": "sha512-/ZAXNipt9nRR8k+eowwukE/YjXnQ49p5w/MkaQxsBk3IuIf7MAcgVg8glHr0igH84GfUQ7ZVP8v+G2S3tKUG+Q==",
-      "dependencies": {
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/util-uri-escape": "3.55.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.55.0.tgz",
-      "integrity": "sha512-e+2FLgo+eDx7oh7ap5HngN9XSVMxredAVztLHxCcSN0lFHHHzMa8b2SpXbaowUxQHh7ziymSqvOrPYFQ71Filg==",
-      "dependencies": {
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.55.0.tgz",
-      "integrity": "sha512-HdjnDyarsa1Avq1MJurkLyEe9c3eRa76dPmK4TmRGgwJ+tInEzGHL0rBW7V8xBK+PDF+fJQ71hvm8jPYmzvBwQ==",
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.58.0.tgz",
-      "integrity": "sha512-ARDKQerIzgNs/MFNdCEuK2lgRJ1lneAaJw0p9O1LkJUvcSibvkSATwny7vwJMueOf+ae1Pf+8+54OMNIt0nTkQ==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.58.0.tgz",
-      "integrity": "sha512-flEo8p3XkzWoBDqnIUQre4jLuT5aLnmfQNI8c2uSjyJ3OBxpJ0iS1cDu3E++d1/pN6Q8o0KOmr2ypHeiyBOujw==",
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/util-hex-encoding": "3.58.0",
-        "@aws-sdk/util-middleware": "3.55.0",
-        "@aws-sdk/util-uri-escape": "3.55.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
     "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.55.0.tgz",
-      "integrity": "sha512-YgBpqg6R3Qg8CH9biOP1N1lYTvh8VLGD6AoDGgy/R1dQSqRQuxgKANLl3DOVcZnIZLsw4TdB0m7U+ZPtirPR1Q==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.342.0.tgz",
+      "integrity": "sha512-HQ4JejjHU2X7OAZPwixFG+EyPSjmoZqll7EvWjPSKyclWrM320haWWz1trVzjG/AgPfeDLfRkH/JoMr13lECew==",
       "dependencies": {
-        "@aws-sdk/middleware-stack": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/middleware-stack": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.345.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.345.0.tgz",
+      "integrity": "sha512-Yhmc8j96LwFU3Fo6H2GYDTALZMGuuOw6PmYhjXa5kzgb9K7hfwiSn8hVyYTVenqkbyUdOuMI6BgXoIgZcdjFmA==",
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.345.0",
+        "@aws-sdk/property-provider": "3.342.0",
+        "@aws-sdk/shared-ini-file-loader": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.55.0.tgz",
-      "integrity": "sha512-wrDZjuy1CVAYxDCbm3bWQIKMGfNs7XXmG0eG4858Ixgqmq2avsIn5TORy8ynBxcXn9aekV/+tGEQ7BBSYzIVNQ==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.342.0.tgz",
+      "integrity": "sha512-5uyXVda/AgUpdZNJ9JPHxwyxr08miPiZ/CKSMcRdQVjcNnrdzY9m/iM9LvnQT44sQO+IEEkF2IoZIWvZcq199A==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/url-parser": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.55.0.tgz",
-      "integrity": "sha512-qrTwN5xIgTLreqLnZ+x3cAudjNKfxi6srW1H/px2mk4lb2U9B4fpGjZ6VU+XV8U2kR+YlT8J6Jo5iwuVGfC91A==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.342.0.tgz",
+      "integrity": "sha512-r4s/FDK6iywl8l4TqEwIwtNvxWO0kZes03c/yCiRYqxlkjVmbXEOodn5IAAweAeS9yqC3sl/wKbsaoBiGFn45g==",
       "dependencies": {
-        "@aws-sdk/querystring-parser": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/querystring-parser": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.55.0.tgz",
-      "integrity": "sha512-76KJxp4MRWufHYWys7DFl64znr5yeJ3AIQNAPCKKw1sP0hzO7p6Kx0PaJnw9x+CPSzOrT4NbuApL6/srYhKDGg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.310.0.tgz",
+      "integrity": "sha512-jL8509owp/xB9+Or0pvn3Fe+b94qfklc2yPowZZIFAkFcCSIdkIglz18cPDWnYAcy9JGewpMS1COXKIUhZkJsA==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-base64-browser": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.58.0.tgz",
-      "integrity": "sha512-0ebsXIZNpu/fup9OgsFPnRKfCFbuuI9PPRzvP6twzLxUB0c/aix6Co7LGHFKcRKHZdaykoJMXArf8eHj2Nzv1Q==",
+    "node_modules/@aws-sdk/util-base64": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.310.0.tgz",
+      "integrity": "sha512-v3+HBKQvqgdzcbL+pFswlx5HQsd9L6ZTlyPVL2LS9nNXnCcR3XgGz9jRskikRUuUvUXtkSG1J88GAOnJ/apTPg==",
       "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/util-base64-node": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.55.0.tgz",
-      "integrity": "sha512-UQ/ZuNoAc8CFMpSiRYmevaTsuRKzLwulZTnM8LNlIt9Wx1tpNvqp80cfvVj7yySKROtEi20wq29h31dZf1eYNQ==",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-body-length-browser": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.55.0.tgz",
-      "integrity": "sha512-Ei2OCzXQw5N6ZkTMZbamUzc1z+z1R1Ja5tMEagz5BxuX4vWdBObT+uGlSzL8yvTbjoPjnxWA2aXyEqaUP3JS8Q==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.310.0.tgz",
+      "integrity": "sha512-sxsC3lPBGfpHtNTUoGXMQXLwjmR0zVpx0rSvzTPAuoVILVsp5AU/w5FphNPxD5OVIjNbZv9KsKTuvNTiZjDp9g==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-body-length-node": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.55.0.tgz",
-      "integrity": "sha512-lU1d4I+9wJwydduXs0SxSfd+mHKjxeyd39VwOv6i2KSwWkPbji9UQqpflKLKw+r45jL7+xU/zfeTUg5Tt/3Gew==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.310.0.tgz",
+      "integrity": "sha512-2tqGXdyKhyA6w4zz7UPoS8Ip+7sayOg9BwHNidiGm2ikbDxm1YrCfYXvCBdwaJxa4hJfRVz+aL9e+d3GqPI9pQ==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.55.0.tgz",
-      "integrity": "sha512-uVzKG1UgvnV7XX2FPTylBujYMKBPBaq/qFBxfl0LVNfrty7YjpfieQxAe6yRLD+T0Kir/WDQwGvYC+tOYG3IGA==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.310.0.tgz",
+      "integrity": "sha512-i6LVeXFtGih5Zs8enLrt+ExXY92QV25jtEnTKHsmlFqFAuL3VBeod6boeMXkN2p9lbSVVQ1sAOOYZOHYbYkntw==",
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/is-array-buffer": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.55.0.tgz",
-      "integrity": "sha512-30dzofQQfx6tp1jVZkZ0DGRsT0wwC15nEysKRiAcjncM64A0Cm6sra77d0os3vbKiKoPCI/lMsFr4o3533+qvQ==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.310.0.tgz",
+      "integrity": "sha512-xIBaYo8dwiojCw8vnUcIL4Z5tyfb1v3yjqyJKJWV/dqKUFOOS0U591plmXbM+M/QkXyML3ypon1f8+BoaDExrg==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.55.0.tgz",
-      "integrity": "sha512-OS3gAwR84bHz7ObhjsSJM+grfeaBq3leGrj7xiX4BH3C8J+c10GMo3fqx1pV8Fq5F+9lMmhHpfOocD63SN5Q8A==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.342.0.tgz",
+      "integrity": "sha512-N1ZRvCLbrt4Re9MKU3pLYR0iO+H7GU7RsXG4yAq6DtSWT9WCw6xhIUpeV2T5uxWKL92o3WHNiGjwcebq+N73Bg==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/property-provider": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.58.0.tgz",
-      "integrity": "sha512-KNUCp0MXI+z3Z3pQCKDkx3Stdy1TXDjcUB+ZJFxRTJGIuBYwX4fV6G8s/zeFJi5Qv1ztR3CJ9fWJGsrx9mQ5EA==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.342.0.tgz",
+      "integrity": "sha512-yNa/eX8sELnwM5NONOFR/PCJMHTNrUVklSo/QHy57CT/L3KOqosRNAMnDVMzH1QolGaVN/8jgtDI2xVsvlP+AA==",
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.58.0",
-        "@aws-sdk/credential-provider-imds": "3.58.0",
-        "@aws-sdk/node-config-provider": "3.58.0",
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/config-resolver": "3.342.0",
+        "@aws-sdk/credential-provider-imds": "3.342.0",
+        "@aws-sdk/node-config-provider": "3.342.0",
+        "@aws-sdk/property-provider": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.58.0.tgz",
-      "integrity": "sha512-Rl+jXUzk/FJkOLYfUVYPhKa2aUmTpeobRP31l8IatQltSzDgLyRHO35f6UEs7Ztn5s1jbu/POatLAZ2WjbgVyg==",
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.342.0.tgz",
+      "integrity": "sha512-ZsYF413hkVwSOjvZG6U0SshRtzSg6MtwzO+j90AjpaqgoHAxE5LjO5eVYFfPXTC2U8NhU7xkzASY6++e5bRRnw==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.310.0.tgz",
+      "integrity": "sha512-sVN7mcCCDSJ67pI1ZMtk84SKGqyix6/0A1Ab163YKn+lFBQRMKexleZzpYzNGxYzmQS6VanP/cfU7NiLQOaSfA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.55.0.tgz",
-      "integrity": "sha512-0sPmK2JaJE2BbTcnvybzob/VrFKCXKfN4CUKcvn0yGg/me7Bz+vtzQRB3Xp+YSx+7OtWxzv63wsvHoAnXvgxgg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
+      "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-middleware": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.55.0.tgz",
-      "integrity": "sha512-82fW2XV+rUalv8lkd4VlhpPp6xnXO5n9sckMp1N+TrQ+p8eqxqT0+o8n1/6s9Qsnkw64Y3m6+EfCdc8/uFOY2g==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.342.0.tgz",
+      "integrity": "sha512-P2LYyMP4JUFZBy9DcMvCDxWU34mlShCyrqBZ1ouuGW7UMgRb1PTEvpLAVndIWn9H+1KGDFjMqOWp1FZHr4YZOA==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-retry": {
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.342.0.tgz",
+      "integrity": "sha512-U1LXXtOMAQjU4H9gjYZng8auRponAH0t3vShHMKT8UQggT6Hwz1obdXUZgcLCtcjp/1aEK4MkDwk2JSjuUTaZw==",
+      "dependencies": {
+        "@aws-sdk/service-error-classification": "3.342.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-stream-browser": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.55.0.tgz",
-      "integrity": "sha512-3f/zQsAqexJpKssCL0adTjG8WO+NPQ63E3TingyKpnCnHQPEnqPdya5I5OLGzZ0WR0iUWRtpuW0MtuDabyLDWw==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.342.0.tgz",
+      "integrity": "sha512-9mPBlD2cfZmJiZoBmDxJ/FxXsMVoxB74v4aa83Nrk4RUlGGXj4GYcuwP6R0+F0d+1jfKARAwlBozL6I+/ICmoQ==",
       "dependencies": {
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/fetch-http-handler": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/util-base64": "3.310.0",
+        "@aws-sdk/util-hex-encoding": "3.310.0",
+        "@aws-sdk/util-utf8": "3.310.0",
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-stream-node": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.55.0.tgz",
-      "integrity": "sha512-brCK3iENvXEL7BK5eDAdkZ2VuBSvXj7DH9EQezxl4Ntrj1lvb+McOk9WoU/o7yzE7A/bzEJEoNQAPi+VPNbb/w==",
+      "version": "3.344.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.344.0.tgz",
+      "integrity": "sha512-Qn2CdmJyt6I+ofokNl5sa8GfKbuKTne5lw6DOhtGVUbqegyRmCx04Qkxy1fe++jdvf7zqb8V8I95lmlvnGYX1Q==",
       "dependencies": {
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/node-http-handler": "3.344.0",
+        "@aws-sdk/types": "3.342.0",
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.55.0.tgz",
-      "integrity": "sha512-mmdDLUpFCN2nkfwlLdOM54lTD528GiGSPN1qb8XtGLgZsJUmg3uJSFIN2lPeSbEwJB3NFjVas/rnQC48i7mV8w==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.310.0.tgz",
+      "integrity": "sha512-drzt+aB2qo2LgtDoiy/3sVG8w63cgLkqFIa2NFlGpUgHFWTXkqtbgf4L5QdjRGKWhmZsnqkbtL7vkSWEcYDJ4Q==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.58.0.tgz",
-      "integrity": "sha512-aJpqCvT09giJRg5xFTBDBRAVF0k0yq3OEf6UTuiOVf5azlL2MGp6PJ/xkJp9Z06PuQQkwBJ/2nIQZemo02a5Sw==",
+      "version": "3.345.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.345.0.tgz",
+      "integrity": "sha512-q0mUueczB8yQlbGje/1am/seDYvbrMdLXzOfZkSWcY7f0kLWqsdOVb/PvfFnlr9VZYy9EwVfqIXMfchHPxSD5Q==",
       "dependencies": {
-        "@aws-sdk/types": "3.55.0",
+        "@aws-sdk/types": "3.342.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.58.0.tgz",
-      "integrity": "sha512-VlbY/nzWdN2pfLUHqKvnlGBQ6tEeV4jyK9ggAD2Szjj0bkYvaaKwpBKswQmuJpi5/J2v7Bo4ayBLnqDL7PgzLA==",
+      "version": "3.345.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.345.0.tgz",
+      "integrity": "sha512-82N+/Td+QtEoM1j5tepsaIy64nMzgw1/qedE3pyLTFGfuQN7iVVppgS6lSvotX0kzWCgTCYyf9gTOMBOvEaVfg==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/node-config-provider": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8": {
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.310.0.tgz",
+      "integrity": "sha512-DnLfFT8uCO22uOJc0pt0DsSNau1GTisngBCDw8jQuWT5CqogMJu4b/uXmwEqfj8B3GX6Xsz8zOd6JpRlPftQoA==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.310.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.55.0.tgz",
-      "integrity": "sha512-ljzqJcyjfJpEVSIAxwtIS8xMRUly84BdjlBXyp6cu4G8TUufgjNS31LWdhyGhgmW5vYBNr+LTz0Kwf6J+ou7Ug==",
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
       "dependencies": {
         "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/util-utf8-node": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.55.0.tgz",
-      "integrity": "sha512-FsFm7GFaC7j0tlPEm/ri8bU2QCwFW5WKjxUg8lm1oWaxplCpKGUsmcfPJ4sw58GIoyoGu4QXBK60oCWosZYYdQ==",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.55.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/util-waiter": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.55.0.tgz",
-      "integrity": "sha512-Do34MKPFSC/+zVN6vY+FZ+0WN61hzga4nPoAC590AOjs8rW6/H6sDN6Gz1KAZbPnuQUZfvsIJjMxN7lblXHJkQ==",
+      "version": "3.342.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.342.0.tgz",
+      "integrity": "sha512-OkOdrvNW4fBPgYw022MLl2CfmnksSIOIoVvBjL042ksimwoc/pX8qofi4ZqnGrN+d0XifevL/+PMdIhJz4U+Sw==",
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/abort-controller": "3.342.0",
+        "@aws-sdk/types": "3.342.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.55.0.tgz",
-      "integrity": "sha512-BH+i5S2FLprmfSeIuGy3UbNtEoJPVjh8arl5+LV3i2KY/+TmrS4yT8JtztDlDxHF0cMtNLZNO0KEPtsACS6SOg==",
+      "version": "3.310.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.310.0.tgz",
+      "integrity": "sha512-TqELu4mOuSIKQCqj63fGVs86Yh+vBx5nHRpWKNUNhB2nPTpfbziTs5c1X358be3peVWA4wPxW7Nt53KIg1tnNw==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@cspotcode/source-map-consumer": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
-      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
-      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
       "dependencies": {
-        "@cspotcode/source-map-consumer": "0.8.0"
+        "@jridgewell/trace-mapping": "0.3.9"
       },
       "engines": {
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz",
+      "integrity": "sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-1.0.1.tgz",
+      "integrity": "sha512-9OrEn0WfOVtBNYJUjUAn9AOiJ4lzERCJJ/JeZs8E6yajTGxBaFRxUnNBHiNqoDJVg076hY36UmEnPx7xXrvUSg==",
+      "dependencies": {
+        "@smithy/types": "^1.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.0.0.tgz",
+      "integrity": "sha512-kc1m5wPBHQCTixwuaOh9vnak/iJm21DrSf9UK6yDE5S3mQQ4u11pqAUiKWnlrZnYkeLfAI9UEHj9OaMT1v5Umg==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@tsconfig/node10": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
       "dev": true
     },
     "node_modules/@tsconfig/node12": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
       "dev": true
     },
     "node_modules/@tsconfig/node14": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
       "dev": true
     },
     "node_modules/@tsconfig/node16": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true
     },
     "node_modules/@types/aws-lambda": {
-      "version": "8.10.93",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.93.tgz",
-      "integrity": "sha512-Vsyi9ogDAY3REZDjYnXMRJJa62SDvxHXxJI5nGDQdZW058dDE+av/anynN2rLKbCKXDRNw3D/sQmqxVflZFi4A==",
+      "version": "8.10.116",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.116.tgz",
+      "integrity": "sha512-LSvIyxYCsIMOiBnb5D6HTf7JXLCh3KPiZWL6Pkn1MqV/v5OoP42GDqn5H4wHKGGKN0mJB+4y1r0oat1dLBAkuA==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -1298,9 +1492,9 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1325,9 +1519,9 @@
       "dev": true
     },
     "node_modules/aws-cdk": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.19.0.tgz",
-      "integrity": "sha512-qOwxDKd1xKsiBW3laYrFBiAF510okJvslEeHViO08SKIyhitUe/HTn2iqfdVBb/zF6wSdm/sRsj2WNHpiKFcBQ==",
+      "version": "2.82.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.82.0.tgz",
+      "integrity": "sha512-4uAhKN8HMdxxM10Th8aMQJLSINO6evYV9UKTPL0hbVQ6dh6+i5LbSejcvDRw0HfBoP6qV1LNV8P8XGLYIC3tyQ==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -1340,9 +1534,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.19.0.tgz",
-      "integrity": "sha512-zt0lAsTpYfrDitjJXp1smEi4o1EYtAAj4fb0WW4GYBW+P6FqymXyAF5mUT8YWPkMJTnSP8d4FeDUyatQVWYRJA==",
+      "version": "2.82.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.82.0.tgz",
+      "integrity": "sha512-icLhHvoxxo5mu9z8oplSHF+A7scbRiXYoRp2hyFkYSCoY9H+eBeIVXKA2S5YPpJfJO4SeORbCQnsyXBbz31XXw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1352,17 +1546,22 @@
         "minimatch",
         "punycode",
         "semver",
+        "table",
         "yaml"
       ],
       "dependencies": {
+        "@aws-cdk/asset-awscli-v1": "^2.2.177",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
+        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.148",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^9.1.0",
-        "ignore": "^5.2.0",
-        "jsonschema": "^1.4.0",
+        "fs-extra": "^11.1.1",
+        "ignore": "^5.2.4",
+        "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
-        "punycode": "^2.1.1",
-        "semver": "^7.3.5",
+        "punycode": "^2.3.0",
+        "semver": "^7.5.1",
+        "table": "^6.8.1",
         "yaml": "1.10.2"
       },
       "engines": {
@@ -1377,12 +1576,49 @@
       "inBundle": true,
       "license": "Apache-2.0"
     },
-    "node_modules/aws-cdk-lib/node_modules/at-least-node": {
-      "version": "1.0.0",
+    "node_modules/aws-cdk-lib/node_modules/ajv": {
+      "version": "8.12.0",
       "inBundle": true,
-      "license": "ISC",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/astral-regex": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/balanced-match": {
@@ -1407,37 +1643,75 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/aws-cdk-lib/node_modules/color-convert": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/color-name": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/aws-cdk-lib/node_modules/concat-map": {
       "version": "0.0.1",
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "9.1.0",
+      "version": "11.1.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.14"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
-      "version": "4.2.9",
+      "version": "4.2.11",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
-      "version": "5.2.0",
+      "version": "5.2.4",
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
       "version": "6.1.0",
@@ -1451,12 +1725,17 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/jsonschema": {
-      "version": "1.4.0",
+      "version": "1.4.1",
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/lru-cache": {
       "version": "6.0.0",
@@ -1481,15 +1760,23 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/punycode": {
-      "version": "2.1.1",
+      "version": "2.3.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
+    "node_modules/aws-cdk-lib/node_modules/require-from-string": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.3.5",
+      "version": "7.5.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -1502,12 +1789,75 @@
         "node": ">=10"
       }
     },
+    "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/string-width": {
+      "version": "4.2.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/table": {
+      "version": "6.8.1",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/aws-cdk-lib/node_modules/universalify": {
       "version": "2.0.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/uri-js": {
+      "version": "4.4.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/yallist": {
@@ -1534,11 +1884,11 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/constructs": {
-      "version": "10.0.106",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.0.106.tgz",
-      "integrity": "sha512-6k8z7O3q6UigE62QW/z34YcSqa1elCDEGz1rTwaMkiVjdL93mB6YLNCpC21FYVUbx+rauTdsQCD3ejVxdAmazg==",
+      "version": "10.2.44",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.2.44.tgz",
+      "integrity": "sha512-7v4KnradGM1JeOuuhey4m9t6pLkwc0XOlgO1TrjB8HLRbfxDHeJ10Tt6IfxihgkrDjYN1SOMmpeVFzLLNjGRQw==",
       "engines": {
-        "node": ">= 12.7.0"
+        "node": ">= 16.14.0"
       }
     },
     "node_modules/create-require": {
@@ -1556,18 +1906,10 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/esbuild": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.31.tgz",
-      "integrity": "sha512-QA0fUM13+JZzcvg1bdrhi7wo8Lr5IRHA9ypNn2znqxGqb66dSK6pAh01TjyBOhzZGazPQJZ1K26VrCAQJ715qA==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.54.tgz",
+      "integrity": "sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -1577,32 +1919,33 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "esbuild-android-64": "0.14.31",
-        "esbuild-android-arm64": "0.14.31",
-        "esbuild-darwin-64": "0.14.31",
-        "esbuild-darwin-arm64": "0.14.31",
-        "esbuild-freebsd-64": "0.14.31",
-        "esbuild-freebsd-arm64": "0.14.31",
-        "esbuild-linux-32": "0.14.31",
-        "esbuild-linux-64": "0.14.31",
-        "esbuild-linux-arm": "0.14.31",
-        "esbuild-linux-arm64": "0.14.31",
-        "esbuild-linux-mips64le": "0.14.31",
-        "esbuild-linux-ppc64le": "0.14.31",
-        "esbuild-linux-riscv64": "0.14.31",
-        "esbuild-linux-s390x": "0.14.31",
-        "esbuild-netbsd-64": "0.14.31",
-        "esbuild-openbsd-64": "0.14.31",
-        "esbuild-sunos-64": "0.14.31",
-        "esbuild-windows-32": "0.14.31",
-        "esbuild-windows-64": "0.14.31",
-        "esbuild-windows-arm64": "0.14.31"
+        "@esbuild/linux-loong64": "0.14.54",
+        "esbuild-android-64": "0.14.54",
+        "esbuild-android-arm64": "0.14.54",
+        "esbuild-darwin-64": "0.14.54",
+        "esbuild-darwin-arm64": "0.14.54",
+        "esbuild-freebsd-64": "0.14.54",
+        "esbuild-freebsd-arm64": "0.14.54",
+        "esbuild-linux-32": "0.14.54",
+        "esbuild-linux-64": "0.14.54",
+        "esbuild-linux-arm": "0.14.54",
+        "esbuild-linux-arm64": "0.14.54",
+        "esbuild-linux-mips64le": "0.14.54",
+        "esbuild-linux-ppc64le": "0.14.54",
+        "esbuild-linux-riscv64": "0.14.54",
+        "esbuild-linux-s390x": "0.14.54",
+        "esbuild-netbsd-64": "0.14.54",
+        "esbuild-openbsd-64": "0.14.54",
+        "esbuild-sunos-64": "0.14.54",
+        "esbuild-windows-32": "0.14.54",
+        "esbuild-windows-64": "0.14.54",
+        "esbuild-windows-arm64": "0.14.54"
       }
     },
     "node_modules/esbuild-android-64": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.31.tgz",
-      "integrity": "sha512-MYkuJ91w07nGmr4EouejOZK2j/f5TCnsKxY8vRr2+wpKKfHD1LTJK28VbZa+y1+AL7v1V9G98ezTUwsV3CmXNw==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz",
+      "integrity": "sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==",
       "cpu": [
         "x64"
       ],
@@ -1616,9 +1959,9 @@
       }
     },
     "node_modules/esbuild-android-arm64": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.31.tgz",
-      "integrity": "sha512-0rkH/35s7ZVcsw6nS0IAkR0dekSbjZGWdlOAf3jV0lGoPqqw0x6/TmaV9w7DQgUERTH1ApmPlpAMU4kVkCq9Jg==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz",
+      "integrity": "sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==",
       "cpu": [
         "arm64"
       ],
@@ -1632,9 +1975,9 @@
       }
     },
     "node_modules/esbuild-darwin-64": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.31.tgz",
-      "integrity": "sha512-kP6xPZHxtJa36Hb0jC05L3VzQSZBW2f3bpnQS20czXTRGEmM2GDiYpGdI5g2QYaw6vC4PYXjnigq8usd9g9jnQ==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz",
+      "integrity": "sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==",
       "cpu": [
         "x64"
       ],
@@ -1648,9 +1991,9 @@
       }
     },
     "node_modules/esbuild-darwin-arm64": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.31.tgz",
-      "integrity": "sha512-1ZMog4hkNsdBGtDDtsftUqX6S9N52gEx4vX5aVehsSptgoBFIar1XrPiBTQty7YNH+bJasTpSVaZQgElCVvPKQ==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz",
+      "integrity": "sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==",
       "cpu": [
         "arm64"
       ],
@@ -1664,9 +2007,9 @@
       }
     },
     "node_modules/esbuild-freebsd-64": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.31.tgz",
-      "integrity": "sha512-Zo0BYj7QpVFWoUpkv6Ng0RO2eJ4zk/WDaHMO88+jr5HuYmxsOre0imgwaZVPquTuJnCvL1G48BFucJ3tFflSeQ==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz",
+      "integrity": "sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==",
       "cpu": [
         "x64"
       ],
@@ -1680,9 +2023,9 @@
       }
     },
     "node_modules/esbuild-freebsd-arm64": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.31.tgz",
-      "integrity": "sha512-t85bS6jbRpmdjr4pdr/FY/fpx8lo1vv9S7BAs2EsXKJQhRDMIiC3QW+k2acYJoRuqirlvJcJVFQGCq/PfyC1kA==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz",
+      "integrity": "sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==",
       "cpu": [
         "arm64"
       ],
@@ -1696,9 +2039,9 @@
       }
     },
     "node_modules/esbuild-linux-32": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.31.tgz",
-      "integrity": "sha512-XYtOk/GodSkv+UOYVwryGpGPuFnszsMvRMKq6cIUfFfdssHuKDsU9IZveyCG44J106J39ABenQ5EetbYtVJHUw==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz",
+      "integrity": "sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==",
       "cpu": [
         "ia32"
       ],
@@ -1712,9 +2055,9 @@
       }
     },
     "node_modules/esbuild-linux-64": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.31.tgz",
-      "integrity": "sha512-Zf9CZxAxaXWHLqCg/QZ/hs0RU0XV3IBxV+ENQzy00S4QOTnZAvSLgPciILHHrVJ0lPIlb4XzAqlLM5y6iI2LIw==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz",
+      "integrity": "sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==",
       "cpu": [
         "x64"
       ],
@@ -1728,9 +2071,9 @@
       }
     },
     "node_modules/esbuild-linux-arm": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.31.tgz",
-      "integrity": "sha512-RpiaeHPRlgCCDskxoyIsI49BhcDtZ4cl8+SLffizDm0yMNWP538SUg0ezQ2TTOPj3/svaGIbkRDwYtAon0Sjkg==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz",
+      "integrity": "sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==",
       "cpu": [
         "arm"
       ],
@@ -1744,9 +2087,9 @@
       }
     },
     "node_modules/esbuild-linux-arm64": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.31.tgz",
-      "integrity": "sha512-V/H0tv+xpQ9IOHM+o85oCKNNidIEc5CcnDWl0V+hPd2F03dqdbFkWPBGphx8rD4JSQn6UefUQ1iH7y1qIzO8Fw==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz",
+      "integrity": "sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==",
       "cpu": [
         "arm64"
       ],
@@ -1760,9 +2103,9 @@
       }
     },
     "node_modules/esbuild-linux-mips64le": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.31.tgz",
-      "integrity": "sha512-9/oBfAckInRuUg6AEgdCLLn6KJ6UOJDOLmUinTsReVSg6AfV6wxYQJq9iQM2idRogP7GUpomJ+bvCdWXpotQRQ==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz",
+      "integrity": "sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==",
       "cpu": [
         "mips64el"
       ],
@@ -1776,9 +2119,9 @@
       }
     },
     "node_modules/esbuild-linux-ppc64le": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.31.tgz",
-      "integrity": "sha512-NMcb14Pg+8q8raGkzor9/R3vQwKzgxE3694BtO2SDLBwJuL2C1dQ1ZtM1t7ZvArQBgT8RiZVxb0/3fD+qGNk7g==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz",
+      "integrity": "sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1792,9 +2135,9 @@
       }
     },
     "node_modules/esbuild-linux-riscv64": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.31.tgz",
-      "integrity": "sha512-l13yvmsVfawAnoYfcpuvml+nTlrOmtdceXYufSkXl2DOb0JKcuR6ARlAzuQCDcpo49SOJy1cCxpwlOIsUQBfzA==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz",
+      "integrity": "sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==",
       "cpu": [
         "riscv64"
       ],
@@ -1808,9 +2151,9 @@
       }
     },
     "node_modules/esbuild-linux-s390x": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.31.tgz",
-      "integrity": "sha512-GIwV9mY3koYja9MCSkKLk1P7rj+MkPV0UsGsZ575hEcIBrXeKN9jBi6X/bxDDPEN/SUAH35cJhBNrZU4x9lEfg==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz",
+      "integrity": "sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==",
       "cpu": [
         "s390x"
       ],
@@ -1824,9 +2167,9 @@
       }
     },
     "node_modules/esbuild-netbsd-64": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.31.tgz",
-      "integrity": "sha512-bJ+pyLvKQm+Obp5k7/Wk8e9Gdkls56F1aiI3uptoIfOIUqsZImH7pDyTrSufwqsFp62kO9LRuwXnjDwQtPyhFQ==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz",
+      "integrity": "sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==",
       "cpu": [
         "x64"
       ],
@@ -1840,9 +2183,9 @@
       }
     },
     "node_modules/esbuild-openbsd-64": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.31.tgz",
-      "integrity": "sha512-NRAAPPca05H9j9Xab0kVXK0V6/pyZGGy8d2Y8KS0BMwWEydlD4KCJDmH8/7bWCKYLRGOOCE9/GPBJyPWHFW3sg==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz",
+      "integrity": "sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==",
       "cpu": [
         "x64"
       ],
@@ -1856,9 +2199,9 @@
       }
     },
     "node_modules/esbuild-sunos-64": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.31.tgz",
-      "integrity": "sha512-9uA+V8w9Eehu4ldb95lPWdgCMcMO5HH6pXmfkk5usn3JsSZxKdLKsXB4hYgP80wscZvVYXJl2G+KNxsUTfPhZw==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz",
+      "integrity": "sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==",
       "cpu": [
         "x64"
       ],
@@ -1872,9 +2215,9 @@
       }
     },
     "node_modules/esbuild-windows-32": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.31.tgz",
-      "integrity": "sha512-VGdncQTqoxD9q3v/dk0Yugbmx2FzOkcs0OemBYc1X9KXOLQYH0uQbLJIckZdZOC3J+JKSExbYFrzYCOwWPuNyA==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz",
+      "integrity": "sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==",
       "cpu": [
         "ia32"
       ],
@@ -1888,9 +2231,9 @@
       }
     },
     "node_modules/esbuild-windows-64": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.31.tgz",
-      "integrity": "sha512-v/2ye5zBqpmCzi3bLCagStbNQlnOsY7WtMrD2Q0xZxeSIXONxji15KYtVee5o7nw4lXWbQSS1BL8G6BBMvtq4A==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz",
+      "integrity": "sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==",
       "cpu": [
         "x64"
       ],
@@ -1904,9 +2247,9 @@
       }
     },
     "node_modules/esbuild-windows-arm64": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.31.tgz",
-      "integrity": "sha512-RXeU42FJoG1sriNHg73h4S+5B7L/gw+8T7U9u8IWqSSEbY6fZvBh4uofugiU1szUDqqP00GHwZ09WgYe3lGZiw==",
+      "version": "0.14.54",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz",
+      "integrity": "sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==",
       "cpu": [
         "arm64"
       ],
@@ -1920,11 +2263,14 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
-      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
       "bin": {
-        "xml2js": "cli.js"
+        "fxparser": "src/cli/cli.js"
       },
       "funding": {
         "type": "paypal",
@@ -1968,13 +2314,18 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+    },
     "node_modules/ts-node": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
-      "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
       "dependencies": {
-        "@cspotcode/source-map-support": "0.7.0",
+        "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
         "@tsconfig/node12": "^1.0.7",
         "@tsconfig/node14": "^1.0.0",
@@ -1985,7 +2336,7 @@
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.0",
+        "v8-compile-cache-lib": "^3.0.1",
         "yn": "3.1.1"
       },
       "bin": {
@@ -2012,14 +2363,14 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
+      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
     },
     "node_modules/typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -2038,9 +2389,9 @@
       }
     },
     "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
-      "integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "node_modules/yn": {
@@ -2051,1513 +2402,6 @@
       "engines": {
         "node": ">=6"
       }
-    }
-  },
-  "dependencies": {
-    "@aws-crypto/crc32": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-2.0.0.tgz",
-      "integrity": "sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==",
-      "requires": {
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-crypto/crc32c": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-2.0.0.tgz",
-      "integrity": "sha512-vF0eMdMHx3O3MoOXUfBZry8Y4ZDtcuskjjKgJz8YfIDjLStxTZrYXk+kZqtl6A0uCmmiN/Eb/JbC/CndTV1MHg==",
-      "requires": {
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-crypto/ie11-detection": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
-      "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
-      "requires": {
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-crypto/sha1-browser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-2.0.0.tgz",
-      "integrity": "sha512-3fIVRjPFY8EG5HWXR+ZJZMdWNRpwbxGzJ9IH9q93FpbgCH8u8GHRi46mZXp3cYD7gealmyqpm3ThZwLKJjWJhA==",
-      "requires": {
-        "@aws-crypto/ie11-detection": "^2.0.0",
-        "@aws-crypto/supports-web-crypto": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-crypto/sha256-browser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
-      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
-      "requires": {
-        "@aws-crypto/ie11-detection": "^2.0.0",
-        "@aws-crypto/sha256-js": "^2.0.0",
-        "@aws-crypto/supports-web-crypto": "^2.0.0",
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-crypto/sha256-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
-      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
-      "requires": {
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-crypto/supports-web-crypto": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
-      "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
-      "requires": {
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-crypto/util": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
-      "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
-      "requires": {
-        "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@aws-sdk/abort-controller": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.55.0.tgz",
-      "integrity": "sha512-rCcTxJDEFnmvo/PgbhCRv24/Uv03lEGfRslKZq7SjaMcOubflS/ZXYaMEgsjYHgAT0zlpSsyCIkJXmhFaM7H7w==",
-      "requires": {
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/chunked-blob-reader": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.55.0.tgz",
-      "integrity": "sha512-o/xjMCq81opAjSBjt7YdHJwIJcGVG5XIV9+C2KXcY5QwVimkOKPybWTv0mXPvSwSilSx+EhpLNhkcJuXdzhw4w==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/chunked-blob-reader-native": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.58.0.tgz",
-      "integrity": "sha512-+D3xnPD5985iphgAqgUerBDs371a2WzzoEVi7eHJUMMsP/gEnSTdSH0HNxsqhYv6CW4EdKtvDAQdAwA1VtCf2A==",
-      "requires": {
-        "@aws-sdk/util-base64-browser": "3.58.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/client-ivs": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ivs/-/client-ivs-3.58.0.tgz",
-      "integrity": "sha512-3h7n1avdHDKOjTKf2s3Wn7uKd/bvnZjGDxjbePPBN0I/QZw10k++mtJNIzmO3yom5ZzKjDBoyZ+9qCxmnazDlg==",
-      "requires": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.58.0",
-        "@aws-sdk/config-resolver": "3.58.0",
-        "@aws-sdk/credential-provider-node": "3.58.0",
-        "@aws-sdk/fetch-http-handler": "3.58.0",
-        "@aws-sdk/hash-node": "3.55.0",
-        "@aws-sdk/invalid-dependency": "3.55.0",
-        "@aws-sdk/middleware-content-length": "3.58.0",
-        "@aws-sdk/middleware-host-header": "3.58.0",
-        "@aws-sdk/middleware-logger": "3.55.0",
-        "@aws-sdk/middleware-retry": "3.58.0",
-        "@aws-sdk/middleware-serde": "3.55.0",
-        "@aws-sdk/middleware-signing": "3.58.0",
-        "@aws-sdk/middleware-stack": "3.55.0",
-        "@aws-sdk/middleware-user-agent": "3.58.0",
-        "@aws-sdk/node-config-provider": "3.58.0",
-        "@aws-sdk/node-http-handler": "3.58.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/smithy-client": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/url-parser": "3.55.0",
-        "@aws-sdk/util-base64-browser": "3.58.0",
-        "@aws-sdk/util-base64-node": "3.55.0",
-        "@aws-sdk/util-body-length-browser": "3.55.0",
-        "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.55.0",
-        "@aws-sdk/util-defaults-mode-node": "3.58.0",
-        "@aws-sdk/util-user-agent-browser": "3.58.0",
-        "@aws-sdk/util-user-agent-node": "3.58.0",
-        "@aws-sdk/util-utf8-browser": "3.55.0",
-        "@aws-sdk/util-utf8-node": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/client-s3": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.58.0.tgz",
-      "integrity": "sha512-7TAqYFpFeaahLCdIxsdWLz3uRrzITFFFitbfVxQ+eaR6EMuH3VEhbGEZ66+zieWns9a1UXc11918vpwgu0zTtw==",
-      "requires": {
-        "@aws-crypto/sha1-browser": "2.0.0",
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.58.0",
-        "@aws-sdk/config-resolver": "3.58.0",
-        "@aws-sdk/credential-provider-node": "3.58.0",
-        "@aws-sdk/eventstream-serde-browser": "3.58.0",
-        "@aws-sdk/eventstream-serde-config-resolver": "3.55.0",
-        "@aws-sdk/eventstream-serde-node": "3.58.0",
-        "@aws-sdk/fetch-http-handler": "3.58.0",
-        "@aws-sdk/hash-blob-browser": "3.58.0",
-        "@aws-sdk/hash-node": "3.55.0",
-        "@aws-sdk/hash-stream-node": "3.58.0",
-        "@aws-sdk/invalid-dependency": "3.55.0",
-        "@aws-sdk/md5-js": "3.58.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.58.0",
-        "@aws-sdk/middleware-content-length": "3.58.0",
-        "@aws-sdk/middleware-expect-continue": "3.58.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.58.0",
-        "@aws-sdk/middleware-host-header": "3.58.0",
-        "@aws-sdk/middleware-location-constraint": "3.55.0",
-        "@aws-sdk/middleware-logger": "3.55.0",
-        "@aws-sdk/middleware-retry": "3.58.0",
-        "@aws-sdk/middleware-sdk-s3": "3.58.0",
-        "@aws-sdk/middleware-serde": "3.55.0",
-        "@aws-sdk/middleware-signing": "3.58.0",
-        "@aws-sdk/middleware-ssec": "3.55.0",
-        "@aws-sdk/middleware-stack": "3.55.0",
-        "@aws-sdk/middleware-user-agent": "3.58.0",
-        "@aws-sdk/node-config-provider": "3.58.0",
-        "@aws-sdk/node-http-handler": "3.58.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/smithy-client": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/url-parser": "3.55.0",
-        "@aws-sdk/util-base64-browser": "3.58.0",
-        "@aws-sdk/util-base64-node": "3.55.0",
-        "@aws-sdk/util-body-length-browser": "3.55.0",
-        "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.55.0",
-        "@aws-sdk/util-defaults-mode-node": "3.58.0",
-        "@aws-sdk/util-stream-browser": "3.55.0",
-        "@aws-sdk/util-stream-node": "3.55.0",
-        "@aws-sdk/util-user-agent-browser": "3.58.0",
-        "@aws-sdk/util-user-agent-node": "3.58.0",
-        "@aws-sdk/util-utf8-browser": "3.55.0",
-        "@aws-sdk/util-utf8-node": "3.55.0",
-        "@aws-sdk/util-waiter": "3.55.0",
-        "@aws-sdk/xml-builder": "3.55.0",
-        "entities": "2.2.0",
-        "fast-xml-parser": "3.19.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/client-sso": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.58.0.tgz",
-      "integrity": "sha512-nS5G/OX8Bg4ajBa6+jLcbbr4PpEO+l5eJfGUzoJQwS4Zqa0lF/wC0kyjKm61gLp4JuvhrQskxIC/3IXUqB1XVQ==",
-      "requires": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.58.0",
-        "@aws-sdk/fetch-http-handler": "3.58.0",
-        "@aws-sdk/hash-node": "3.55.0",
-        "@aws-sdk/invalid-dependency": "3.55.0",
-        "@aws-sdk/middleware-content-length": "3.58.0",
-        "@aws-sdk/middleware-host-header": "3.58.0",
-        "@aws-sdk/middleware-logger": "3.55.0",
-        "@aws-sdk/middleware-retry": "3.58.0",
-        "@aws-sdk/middleware-serde": "3.55.0",
-        "@aws-sdk/middleware-stack": "3.55.0",
-        "@aws-sdk/middleware-user-agent": "3.58.0",
-        "@aws-sdk/node-config-provider": "3.58.0",
-        "@aws-sdk/node-http-handler": "3.58.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/smithy-client": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/url-parser": "3.55.0",
-        "@aws-sdk/util-base64-browser": "3.58.0",
-        "@aws-sdk/util-base64-node": "3.55.0",
-        "@aws-sdk/util-body-length-browser": "3.55.0",
-        "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.55.0",
-        "@aws-sdk/util-defaults-mode-node": "3.58.0",
-        "@aws-sdk/util-user-agent-browser": "3.58.0",
-        "@aws-sdk/util-user-agent-node": "3.58.0",
-        "@aws-sdk/util-utf8-browser": "3.55.0",
-        "@aws-sdk/util-utf8-node": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/client-sts": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.58.0.tgz",
-      "integrity": "sha512-2cHZsG2eXv/Zl0hvsG9+rdHEuAclMFfkma/3LC3RRwSuZXo1rXoIhFkzHfGfIbivdk738YAo7FT3ZYGlrsK4ow==",
-      "requires": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.58.0",
-        "@aws-sdk/credential-provider-node": "3.58.0",
-        "@aws-sdk/fetch-http-handler": "3.58.0",
-        "@aws-sdk/hash-node": "3.55.0",
-        "@aws-sdk/invalid-dependency": "3.55.0",
-        "@aws-sdk/middleware-content-length": "3.58.0",
-        "@aws-sdk/middleware-host-header": "3.58.0",
-        "@aws-sdk/middleware-logger": "3.55.0",
-        "@aws-sdk/middleware-retry": "3.58.0",
-        "@aws-sdk/middleware-sdk-sts": "3.58.0",
-        "@aws-sdk/middleware-serde": "3.55.0",
-        "@aws-sdk/middleware-signing": "3.58.0",
-        "@aws-sdk/middleware-stack": "3.55.0",
-        "@aws-sdk/middleware-user-agent": "3.58.0",
-        "@aws-sdk/node-config-provider": "3.58.0",
-        "@aws-sdk/node-http-handler": "3.58.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/smithy-client": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/url-parser": "3.55.0",
-        "@aws-sdk/util-base64-browser": "3.58.0",
-        "@aws-sdk/util-base64-node": "3.55.0",
-        "@aws-sdk/util-body-length-browser": "3.55.0",
-        "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.55.0",
-        "@aws-sdk/util-defaults-mode-node": "3.58.0",
-        "@aws-sdk/util-user-agent-browser": "3.58.0",
-        "@aws-sdk/util-user-agent-node": "3.58.0",
-        "@aws-sdk/util-utf8-browser": "3.55.0",
-        "@aws-sdk/util-utf8-node": "3.55.0",
-        "entities": "2.2.0",
-        "fast-xml-parser": "3.19.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/config-resolver": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.58.0.tgz",
-      "integrity": "sha512-NXEwYw0JrXcvenu42QpNMQXK+6pgZ+6bDGfCgOfCC0FmyI+w/CuF36lApwm7InHvHazOaDlwArXm2pfntErKoA==",
-      "requires": {
-        "@aws-sdk/signature-v4": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/util-config-provider": "3.55.0",
-        "@aws-sdk/util-middleware": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/credential-provider-env": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.55.0.tgz",
-      "integrity": "sha512-4AIIXEdvinLlWNFtrUbUgoB7dkuV04RTcTruVWI4Ub4WSsuSCa72ZU1vqyvcEAOgGGLBmcSaGTWByjiD2sGcGA==",
-      "requires": {
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/credential-provider-imds": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.58.0.tgz",
-      "integrity": "sha512-CdtnTQ9zqLx1FbXdbgjijLbMcIWOyQM03TFaLSCjI3FNbUwyt3T7StBU9tj/LtbypHhSdXyQBpzUtXTOMWCEhg==",
-      "requires": {
-        "@aws-sdk/node-config-provider": "3.58.0",
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/url-parser": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/credential-provider-ini": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.58.0.tgz",
-      "integrity": "sha512-uM62hcHUVaHP1YFnbrjf2RlrRj1m/BvMPE+T5jdNRWdE3lvnunhEMawB26HZs9nQqCV6d25I8G9/fGWVL7g3Og==",
-      "requires": {
-        "@aws-sdk/credential-provider-env": "3.55.0",
-        "@aws-sdk/credential-provider-imds": "3.58.0",
-        "@aws-sdk/credential-provider-sso": "3.58.0",
-        "@aws-sdk/credential-provider-web-identity": "3.55.0",
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/shared-ini-file-loader": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/credential-provider-node": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.58.0.tgz",
-      "integrity": "sha512-f0wzcgMYCQUrii6TLP2ggCxkQP4HH8PW8tbbWEgt4cdIXcjE9KEuxN5yOV6sFHzL3eJh0QM9Yaz8WzhWn6fT2A==",
-      "requires": {
-        "@aws-sdk/credential-provider-env": "3.55.0",
-        "@aws-sdk/credential-provider-imds": "3.58.0",
-        "@aws-sdk/credential-provider-ini": "3.58.0",
-        "@aws-sdk/credential-provider-process": "3.58.0",
-        "@aws-sdk/credential-provider-sso": "3.58.0",
-        "@aws-sdk/credential-provider-web-identity": "3.55.0",
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/shared-ini-file-loader": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/credential-provider-process": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.58.0.tgz",
-      "integrity": "sha512-npgFqPUjMhUamf1FvJjBYUdpbWx8XWkKCwJsX73I7IYQAvAi2atCOkdtKq+4rds0VWAYu6vzlaI1tXgFxjOPNQ==",
-      "requires": {
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/shared-ini-file-loader": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/credential-provider-sso": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.58.0.tgz",
-      "integrity": "sha512-2qO34s9lJqvCC6zOF4UpopW6xURZpYfVC8xTUDpAUnvTOt4nS5hkx4vNyqPAXILoRHuFJsnlWsBH1UP5ZnBiZg==",
-      "requires": {
-        "@aws-sdk/client-sso": "3.58.0",
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/shared-ini-file-loader": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.55.0.tgz",
-      "integrity": "sha512-aKnXfZNGohTuF9rCGYLg4JEIOvWIZ/sb66XMq7bOUrx13KRPDwL/eUQL8quS5jGRLpjXVNvrS17AFf65GbdUBg==",
-      "requires": {
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/eventstream-marshaller": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.58.0.tgz",
-      "integrity": "sha512-vTdVFLIHGZTx/Anp9GpkTXVuvwSCNOecTutU5Py4i6fATgefWiSutc5Xc/FLujBSc0EhAXDGZIcTMpZC7jUpeg==",
-      "requires": {
-        "@aws-crypto/crc32": "2.0.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/util-hex-encoding": "3.58.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/eventstream-serde-browser": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.58.0.tgz",
-      "integrity": "sha512-oR5yoOoJrTSUKwbxZSt37bZgMXUUSsOub96E6SOb8wh8TMq2f0wvqeO8A+aaxY487gKpzuVUClp7jSQ9LgiVcw==",
-      "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.58.0",
-        "@aws-sdk/eventstream-serde-universal": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/eventstream-serde-config-resolver": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.55.0.tgz",
-      "integrity": "sha512-NTJHLq1sbXyXAaJucKvcdN3Svr/fM2TjHEC3l8P/torFjIsX1+Ykpi8tZt8KsX8RjoUTTfKylh41AjJq0K9X4Q==",
-      "requires": {
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/eventstream-serde-node": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.58.0.tgz",
-      "integrity": "sha512-U1DnRVfvKOXty+Bei6oqhRWFzGWzxl0OFHtev9GzC7BE/E6s4Gn695o+NO+9IwQgjOlc/JsGyAcWevq3MDxymg==",
-      "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.58.0",
-        "@aws-sdk/eventstream-serde-universal": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/eventstream-serde-universal": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.58.0.tgz",
-      "integrity": "sha512-w7czmMNvCCspJi8Ij0lTByCiuYBhyNzYTM1wv33vtF7dL+FJgi4W4c5WFAOtvpsPulobY013TWCjPJG+V0IPGQ==",
-      "requires": {
-        "@aws-sdk/eventstream-marshaller": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/fetch-http-handler": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.58.0.tgz",
-      "integrity": "sha512-timF3FjPV5Bd+Kgph83LIKVlPCFObVYzious1a6doeLAT6YFwZpRrWbfP/HzS+DCoYiwUsH69oVJ91BoV66oyA==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/querystring-builder": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/util-base64-browser": "3.58.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/hash-blob-browser": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.58.0.tgz",
-      "integrity": "sha512-fdp12BqypRxwvevbJSl/sUhXJRi4Ghv6JKEXAHI1klkR6xY1GRORO5SHWltVY/xl373ERMol5o/n+ra/7jcx/g==",
-      "requires": {
-        "@aws-sdk/chunked-blob-reader": "3.55.0",
-        "@aws-sdk/chunked-blob-reader-native": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/hash-node": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.55.0.tgz",
-      "integrity": "sha512-2UdYwY/++AlzWEAFaK9wOed2QSxbzV527vmqKjReLHpPKPrSIlooUxlTH3LU6Y6WVDAzDRtLK43KUVXTLgGK1A==",
-      "requires": {
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/util-buffer-from": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/hash-stream-node": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.58.0.tgz",
-      "integrity": "sha512-y7HEeC3OiuXCRqsHnKDn5yef8UAbnegD9r+OM9bdD+3e6FLAL8Rq7hQTOpwIAiPXuD7HKx8h98s9JLvkwTOBkg==",
-      "requires": {
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/invalid-dependency": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.55.0.tgz",
-      "integrity": "sha512-delH0lV+78fdD/8MXIt9kTLS6IwHvdhqq9dw/ow5VjTUw+xBwUlfPfZplaai+3hKTKWh6a2WZCeDasNItBv9aA==",
-      "requires": {
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/is-array-buffer": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.55.0.tgz",
-      "integrity": "sha512-NbiPHVYuPxdqdFd6FxzzN3H1BQn/iWA3ri3Ry7AyLeP/tGs1yzEWMwf8BN8TSMALI0GXT6Sh0GDWy3Ok5xB6DA==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/md5-js": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.58.0.tgz",
-      "integrity": "sha512-V5f4Re+CLn3aDF1nrmDqdUtcqBHCyxxD2s2Ot+hZ2JFit+OtJggo1cI03ldTrQpG79rwHG+bHqL2VvNQP7Aj9A==",
-      "requires": {
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/util-utf8-browser": "3.55.0",
-        "@aws-sdk/util-utf8-node": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.58.0.tgz",
-      "integrity": "sha512-zocLfFzj+NQjXLGZKPJBAYWWldAKBJkGzGVpTfrYx9bxxHTA70Gu+3sx+Xe+iOu8dtQT0OAnIX0wGudOPnTGNg==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/util-arn-parser": "3.55.0",
-        "@aws-sdk/util-config-provider": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-content-length": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.58.0.tgz",
-      "integrity": "sha512-h/BypPkhjv2CpCUbXA8Fa2s7V2GPiz9l11XhYK+sKSuQvQ7Lbq6VhaKaLqfeD3gLVZHgJZSLGl2btdHV1qHNNA==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-expect-continue": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.58.0.tgz",
-      "integrity": "sha512-nx6X6qLPwvbJrGoPxXSu4tsOek2eRnnjk78hhRUDfxFewpHJQLSPlyNKkXAo+C3syVALe6RJRmUYu5bShY6FfA==",
-      "requires": {
-        "@aws-sdk/middleware-header-default": "3.58.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.58.0.tgz",
-      "integrity": "sha512-R8S3U1boaIb7+kYhLJBks7rv/eaGj7I5T/2CgmcGY1BJBUU0h0arjPC7eeA/5wV29EHapoxVYQvJda//706rCw==",
-      "requires": {
-        "@aws-crypto/crc32": "2.0.0",
-        "@aws-crypto/crc32c": "2.0.0",
-        "@aws-sdk/is-array-buffer": "3.55.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-header-default": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.58.0.tgz",
-      "integrity": "sha512-7F+CdLLauMmNbwFGYrE2pKsgTKY8G2PgazHmaE9s3FySEFcGPWmiEAG8sVImfZooj8gxGFQMLr97nanWjhSq2Q==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-host-header": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.58.0.tgz",
-      "integrity": "sha512-q/UKGcanm9e6DBRNN6UKhVqLvpRRdZWbmmPCeDNr4HqhCmgT6i1OvWdhAMOnT++hvCX8DpTsIXzNSlY6zWAxBg==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-location-constraint": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.55.0.tgz",
-      "integrity": "sha512-OvCKwBFbl8Gbfk0HGX00pkdORJN8BPuH/O5l3+mOBWuwILPuckRP5WGnL+1HT/gu4hHS6h1lpxUrPxUOoeKIAg==",
-      "requires": {
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-logger": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.55.0.tgz",
-      "integrity": "sha512-PtRbVrxEzDmeV9prBIP4/9or7R5Dj66mjbFSvNRGZ0n+UBfBFfVRfNrhQPNzQpfV9A3KVl9YyWCVXDSW+/rk9Q==",
-      "requires": {
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-retry": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.58.0.tgz",
-      "integrity": "sha512-sfSq+t0Yy47DQwrWGpA8iOx9sd26l4l1JDVTwHNi7+OKD4ClRPVCEdw3bTbbyYz/PV4f9AEfAZ6jwtSff4wkGw==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/service-error-classification": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/util-middleware": "3.55.0",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2"
-      }
-    },
-    "@aws-sdk/middleware-sdk-s3": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.58.0.tgz",
-      "integrity": "sha512-vOTPOdhZpNJo4v54evg6JnFz14hK8IW2u8B+12iV5ZQ4zJom6VowzFmIOUn+KIsw/6SrwEX9tFb0aXLlVRw27Q==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/signature-v4": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/util-arn-parser": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.58.0.tgz",
-      "integrity": "sha512-HUz7MhcsSDDTGygOwL61l4voc0pZco06J3z06JjTX19D5XxcQ7hSCtkHHHz0oMb9M1himVSiEon2tjhjsnB99g==",
-      "requires": {
-        "@aws-sdk/middleware-signing": "3.58.0",
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/signature-v4": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-serde": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.55.0.tgz",
-      "integrity": "sha512-NkEbTDrSZcC2NhuvfjXHKJEl0xgI2B5tMAwi/rMOq/TEnARwVUL9qAy+5lgeiPCqebiNllWatARrFgAaYf0VeA==",
-      "requires": {
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-signing": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.58.0.tgz",
-      "integrity": "sha512-4FXubHB66GbhyZUlo6YPQoWpYfED15GNbEmHbJLSONzrVzZR3IkViSPLasDngVm1a050JqKuqNkFYGJBP4No/Q==",
-      "requires": {
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/signature-v4": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-ssec": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.55.0.tgz",
-      "integrity": "sha512-HTdA23hksOphQe0TmYORsa/kMNnKRGbdh0VJcsDGHQScJXzJ+C//THwfcoklff0XZfC+vGh93PECBWqixMELZw==",
-      "requires": {
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-stack": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.55.0.tgz",
-      "integrity": "sha512-ouD+wFz8W2R0ZQ8HrbhgN8tg1jyINEg9lPEEXY79w1Q5sf94LJ90XKAMVk02rw3dJalUWjLHf0OQe1/qxZfHyA==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-user-agent": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.58.0.tgz",
-      "integrity": "sha512-1c69bIWM63JwXijXvb9IWwcwQ/gViKMZ1lhxv52NvdG5VSxWXXsFJ2jETEXZoAypwT97Hmf3xo9SYuaHcKoq+g==",
-      "requires": {
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/node-config-provider": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.58.0.tgz",
-      "integrity": "sha512-AMcPqPhKxo/3/yOMS9PsKlI0GWp2/8eD6gSlhzdBpznPCKplyqXOSnSX7wS814Cyh373hFSjCaOrCOA9/EYtDg==",
-      "requires": {
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/shared-ini-file-loader": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/node-http-handler": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.58.0.tgz",
-      "integrity": "sha512-D9xVZG2nfo4GbPsby3JuBiAhpqXTFk1+CfuQU0AZv0gQvE3fFTCnB3za83jo7JV/pyRPU+s+/LHIpxCWUHzStg==",
-      "requires": {
-        "@aws-sdk/abort-controller": "3.55.0",
-        "@aws-sdk/protocol-http": "3.58.0",
-        "@aws-sdk/querystring-builder": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/property-provider": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.55.0.tgz",
-      "integrity": "sha512-o7cKFJSHq5WOhwPsspYrzNto35oKKZvESZuWDtLxaZKSI6l7zpA366BI4kDG6Tc9i2+teV553MbxyZ9eya5A8g==",
-      "requires": {
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/protocol-http": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.58.0.tgz",
-      "integrity": "sha512-0yFFRPbR+CCa9eOQBBQ2qtrIDLYqSMN0y7G4iqVM8wQdIw7n3QK1PsTI3RNPGJ3Oi2krFTw5uUKqQQZPZEBuVQ==",
-      "requires": {
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/querystring-builder": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.55.0.tgz",
-      "integrity": "sha512-/ZAXNipt9nRR8k+eowwukE/YjXnQ49p5w/MkaQxsBk3IuIf7MAcgVg8glHr0igH84GfUQ7ZVP8v+G2S3tKUG+Q==",
-      "requires": {
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/util-uri-escape": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/querystring-parser": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.55.0.tgz",
-      "integrity": "sha512-e+2FLgo+eDx7oh7ap5HngN9XSVMxredAVztLHxCcSN0lFHHHzMa8b2SpXbaowUxQHh7ziymSqvOrPYFQ71Filg==",
-      "requires": {
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/service-error-classification": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.55.0.tgz",
-      "integrity": "sha512-HdjnDyarsa1Avq1MJurkLyEe9c3eRa76dPmK4TmRGgwJ+tInEzGHL0rBW7V8xBK+PDF+fJQ71hvm8jPYmzvBwQ=="
-    },
-    "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.58.0.tgz",
-      "integrity": "sha512-ARDKQerIzgNs/MFNdCEuK2lgRJ1lneAaJw0p9O1LkJUvcSibvkSATwny7vwJMueOf+ae1Pf+8+54OMNIt0nTkQ==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/signature-v4": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.58.0.tgz",
-      "integrity": "sha512-flEo8p3XkzWoBDqnIUQre4jLuT5aLnmfQNI8c2uSjyJ3OBxpJ0iS1cDu3E++d1/pN6Q8o0KOmr2ypHeiyBOujw==",
-      "requires": {
-        "@aws-sdk/is-array-buffer": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "@aws-sdk/util-hex-encoding": "3.58.0",
-        "@aws-sdk/util-middleware": "3.55.0",
-        "@aws-sdk/util-uri-escape": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/smithy-client": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.55.0.tgz",
-      "integrity": "sha512-YgBpqg6R3Qg8CH9biOP1N1lYTvh8VLGD6AoDGgy/R1dQSqRQuxgKANLl3DOVcZnIZLsw4TdB0m7U+ZPtirPR1Q==",
-      "requires": {
-        "@aws-sdk/middleware-stack": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/types": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.55.0.tgz",
-      "integrity": "sha512-wrDZjuy1CVAYxDCbm3bWQIKMGfNs7XXmG0eG4858Ixgqmq2avsIn5TORy8ynBxcXn9aekV/+tGEQ7BBSYzIVNQ=="
-    },
-    "@aws-sdk/url-parser": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.55.0.tgz",
-      "integrity": "sha512-qrTwN5xIgTLreqLnZ+x3cAudjNKfxi6srW1H/px2mk4lb2U9B4fpGjZ6VU+XV8U2kR+YlT8J6Jo5iwuVGfC91A==",
-      "requires": {
-        "@aws-sdk/querystring-parser": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-arn-parser": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.55.0.tgz",
-      "integrity": "sha512-76KJxp4MRWufHYWys7DFl64znr5yeJ3AIQNAPCKKw1sP0hzO7p6Kx0PaJnw9x+CPSzOrT4NbuApL6/srYhKDGg==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-base64-browser": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.58.0.tgz",
-      "integrity": "sha512-0ebsXIZNpu/fup9OgsFPnRKfCFbuuI9PPRzvP6twzLxUB0c/aix6Co7LGHFKcRKHZdaykoJMXArf8eHj2Nzv1Q==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-base64-node": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.55.0.tgz",
-      "integrity": "sha512-UQ/ZuNoAc8CFMpSiRYmevaTsuRKzLwulZTnM8LNlIt9Wx1tpNvqp80cfvVj7yySKROtEi20wq29h31dZf1eYNQ==",
-      "requires": {
-        "@aws-sdk/util-buffer-from": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-body-length-browser": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.55.0.tgz",
-      "integrity": "sha512-Ei2OCzXQw5N6ZkTMZbamUzc1z+z1R1Ja5tMEagz5BxuX4vWdBObT+uGlSzL8yvTbjoPjnxWA2aXyEqaUP3JS8Q==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-body-length-node": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.55.0.tgz",
-      "integrity": "sha512-lU1d4I+9wJwydduXs0SxSfd+mHKjxeyd39VwOv6i2KSwWkPbji9UQqpflKLKw+r45jL7+xU/zfeTUg5Tt/3Gew==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-buffer-from": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.55.0.tgz",
-      "integrity": "sha512-uVzKG1UgvnV7XX2FPTylBujYMKBPBaq/qFBxfl0LVNfrty7YjpfieQxAe6yRLD+T0Kir/WDQwGvYC+tOYG3IGA==",
-      "requires": {
-        "@aws-sdk/is-array-buffer": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-config-provider": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.55.0.tgz",
-      "integrity": "sha512-30dzofQQfx6tp1jVZkZ0DGRsT0wwC15nEysKRiAcjncM64A0Cm6sra77d0os3vbKiKoPCI/lMsFr4o3533+qvQ==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.55.0.tgz",
-      "integrity": "sha512-OS3gAwR84bHz7ObhjsSJM+grfeaBq3leGrj7xiX4BH3C8J+c10GMo3fqx1pV8Fq5F+9lMmhHpfOocD63SN5Q8A==",
-      "requires": {
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.58.0.tgz",
-      "integrity": "sha512-KNUCp0MXI+z3Z3pQCKDkx3Stdy1TXDjcUB+ZJFxRTJGIuBYwX4fV6G8s/zeFJi5Qv1ztR3CJ9fWJGsrx9mQ5EA==",
-      "requires": {
-        "@aws-sdk/config-resolver": "3.58.0",
-        "@aws-sdk/credential-provider-imds": "3.58.0",
-        "@aws-sdk/node-config-provider": "3.58.0",
-        "@aws-sdk/property-provider": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-hex-encoding": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.58.0.tgz",
-      "integrity": "sha512-Rl+jXUzk/FJkOLYfUVYPhKa2aUmTpeobRP31l8IatQltSzDgLyRHO35f6UEs7Ztn5s1jbu/POatLAZ2WjbgVyg==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-locate-window": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.55.0.tgz",
-      "integrity": "sha512-0sPmK2JaJE2BbTcnvybzob/VrFKCXKfN4CUKcvn0yGg/me7Bz+vtzQRB3Xp+YSx+7OtWxzv63wsvHoAnXvgxgg==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-middleware": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.55.0.tgz",
-      "integrity": "sha512-82fW2XV+rUalv8lkd4VlhpPp6xnXO5n9sckMp1N+TrQ+p8eqxqT0+o8n1/6s9Qsnkw64Y3m6+EfCdc8/uFOY2g==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-stream-browser": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.55.0.tgz",
-      "integrity": "sha512-3f/zQsAqexJpKssCL0adTjG8WO+NPQ63E3TingyKpnCnHQPEnqPdya5I5OLGzZ0WR0iUWRtpuW0MtuDabyLDWw==",
-      "requires": {
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-stream-node": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.55.0.tgz",
-      "integrity": "sha512-brCK3iENvXEL7BK5eDAdkZ2VuBSvXj7DH9EQezxl4Ntrj1lvb+McOk9WoU/o7yzE7A/bzEJEoNQAPi+VPNbb/w==",
-      "requires": {
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-uri-escape": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.55.0.tgz",
-      "integrity": "sha512-mmdDLUpFCN2nkfwlLdOM54lTD528GiGSPN1qb8XtGLgZsJUmg3uJSFIN2lPeSbEwJB3NFjVas/rnQC48i7mV8w==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-user-agent-browser": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.58.0.tgz",
-      "integrity": "sha512-aJpqCvT09giJRg5xFTBDBRAVF0k0yq3OEf6UTuiOVf5azlL2MGp6PJ/xkJp9Z06PuQQkwBJ/2nIQZemo02a5Sw==",
-      "requires": {
-        "@aws-sdk/types": "3.55.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-user-agent-node": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.58.0.tgz",
-      "integrity": "sha512-VlbY/nzWdN2pfLUHqKvnlGBQ6tEeV4jyK9ggAD2Szjj0bkYvaaKwpBKswQmuJpi5/J2v7Bo4ayBLnqDL7PgzLA==",
-      "requires": {
-        "@aws-sdk/node-config-provider": "3.58.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-utf8-browser": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.55.0.tgz",
-      "integrity": "sha512-ljzqJcyjfJpEVSIAxwtIS8xMRUly84BdjlBXyp6cu4G8TUufgjNS31LWdhyGhgmW5vYBNr+LTz0Kwf6J+ou7Ug==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-utf8-node": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.55.0.tgz",
-      "integrity": "sha512-FsFm7GFaC7j0tlPEm/ri8bU2QCwFW5WKjxUg8lm1oWaxplCpKGUsmcfPJ4sw58GIoyoGu4QXBK60oCWosZYYdQ==",
-      "requires": {
-        "@aws-sdk/util-buffer-from": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-waiter": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.55.0.tgz",
-      "integrity": "sha512-Do34MKPFSC/+zVN6vY+FZ+0WN61hzga4nPoAC590AOjs8rW6/H6sDN6Gz1KAZbPnuQUZfvsIJjMxN7lblXHJkQ==",
-      "requires": {
-        "@aws-sdk/abort-controller": "3.55.0",
-        "@aws-sdk/types": "3.55.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/xml-builder": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.55.0.tgz",
-      "integrity": "sha512-BH+i5S2FLprmfSeIuGy3UbNtEoJPVjh8arl5+LV3i2KY/+TmrS4yT8JtztDlDxHF0cMtNLZNO0KEPtsACS6SOg==",
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@cspotcode/source-map-consumer": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
-      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
-      "dev": true
-    },
-    "@cspotcode/source-map-support": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
-      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
-      "dev": true,
-      "requires": {
-        "@cspotcode/source-map-consumer": "0.8.0"
-      }
-    },
-    "@tsconfig/node10": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-      "dev": true
-    },
-    "@tsconfig/node12": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-      "dev": true
-    },
-    "@tsconfig/node14": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-      "dev": true
-    },
-    "@tsconfig/node16": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-      "dev": true
-    },
-    "@types/aws-lambda": {
-      "version": "8.10.93",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.93.tgz",
-      "integrity": "sha512-Vsyi9ogDAY3REZDjYnXMRJJa62SDvxHXxJI5nGDQdZW058dDE+av/anynN2rLKbCKXDRNw3D/sQmqxVflZFi4A==",
-      "dev": true
-    },
-    "@types/node": {
-      "version": "17.0.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
-      "dev": true
-    },
-    "acorn": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-      "dev": true
-    },
-    "acorn-walk": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "dev": true
-    },
-    "arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
-    },
-    "aws-cdk": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.19.0.tgz",
-      "integrity": "sha512-qOwxDKd1xKsiBW3laYrFBiAF510okJvslEeHViO08SKIyhitUe/HTn2iqfdVBb/zF6wSdm/sRsj2WNHpiKFcBQ==",
-      "dev": true,
-      "requires": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "aws-cdk-lib": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.19.0.tgz",
-      "integrity": "sha512-zt0lAsTpYfrDitjJXp1smEi4o1EYtAAj4fb0WW4GYBW+P6FqymXyAF5mUT8YWPkMJTnSP8d4FeDUyatQVWYRJA==",
-      "requires": {
-        "@balena/dockerignore": "^1.0.2",
-        "case": "1.6.3",
-        "fs-extra": "^9.1.0",
-        "ignore": "^5.2.0",
-        "jsonschema": "^1.4.0",
-        "minimatch": "^3.1.2",
-        "punycode": "^2.1.1",
-        "semver": "^7.3.5",
-        "yaml": "1.10.2"
-      },
-      "dependencies": {
-        "@balena/dockerignore": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "at-least-node": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "balanced-match": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "case": {
-          "version": "1.6.3",
-          "bundled": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "fs-extra": {
-          "version": "9.1.0",
-          "bundled": true,
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.2.9",
-          "bundled": true
-        },
-        "ignore": {
-          "version": "5.2.0",
-          "bundled": true
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          }
-        },
-        "jsonschema": {
-          "version": "1.4.0",
-          "bundled": true
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "bundled": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.1.2",
-          "bundled": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "punycode": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "semver": {
-          "version": "7.3.5",
-          "bundled": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "universalify": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "bundled": true
-        },
-        "yaml": {
-          "version": "1.10.2",
-          "bundled": true
-        }
-      }
-    },
-    "bowser": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
-    },
-    "buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
-    },
-    "constructs": {
-      "version": "10.0.106",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.0.106.tgz",
-      "integrity": "sha512-6k8z7O3q6UigE62QW/z34YcSqa1elCDEGz1rTwaMkiVjdL93mB6YLNCpC21FYVUbx+rauTdsQCD3ejVxdAmazg=="
-    },
-    "create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
-    },
-    "diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true
-    },
-    "entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
-    },
-    "esbuild": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.31.tgz",
-      "integrity": "sha512-QA0fUM13+JZzcvg1bdrhi7wo8Lr5IRHA9ypNn2znqxGqb66dSK6pAh01TjyBOhzZGazPQJZ1K26VrCAQJ715qA==",
-      "dev": true,
-      "requires": {
-        "esbuild-android-64": "0.14.31",
-        "esbuild-android-arm64": "0.14.31",
-        "esbuild-darwin-64": "0.14.31",
-        "esbuild-darwin-arm64": "0.14.31",
-        "esbuild-freebsd-64": "0.14.31",
-        "esbuild-freebsd-arm64": "0.14.31",
-        "esbuild-linux-32": "0.14.31",
-        "esbuild-linux-64": "0.14.31",
-        "esbuild-linux-arm": "0.14.31",
-        "esbuild-linux-arm64": "0.14.31",
-        "esbuild-linux-mips64le": "0.14.31",
-        "esbuild-linux-ppc64le": "0.14.31",
-        "esbuild-linux-riscv64": "0.14.31",
-        "esbuild-linux-s390x": "0.14.31",
-        "esbuild-netbsd-64": "0.14.31",
-        "esbuild-openbsd-64": "0.14.31",
-        "esbuild-sunos-64": "0.14.31",
-        "esbuild-windows-32": "0.14.31",
-        "esbuild-windows-64": "0.14.31",
-        "esbuild-windows-arm64": "0.14.31"
-      }
-    },
-    "esbuild-android-64": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.31.tgz",
-      "integrity": "sha512-MYkuJ91w07nGmr4EouejOZK2j/f5TCnsKxY8vRr2+wpKKfHD1LTJK28VbZa+y1+AL7v1V9G98ezTUwsV3CmXNw==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-android-arm64": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.31.tgz",
-      "integrity": "sha512-0rkH/35s7ZVcsw6nS0IAkR0dekSbjZGWdlOAf3jV0lGoPqqw0x6/TmaV9w7DQgUERTH1ApmPlpAMU4kVkCq9Jg==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-darwin-64": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.31.tgz",
-      "integrity": "sha512-kP6xPZHxtJa36Hb0jC05L3VzQSZBW2f3bpnQS20czXTRGEmM2GDiYpGdI5g2QYaw6vC4PYXjnigq8usd9g9jnQ==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-darwin-arm64": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.31.tgz",
-      "integrity": "sha512-1ZMog4hkNsdBGtDDtsftUqX6S9N52gEx4vX5aVehsSptgoBFIar1XrPiBTQty7YNH+bJasTpSVaZQgElCVvPKQ==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-freebsd-64": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.31.tgz",
-      "integrity": "sha512-Zo0BYj7QpVFWoUpkv6Ng0RO2eJ4zk/WDaHMO88+jr5HuYmxsOre0imgwaZVPquTuJnCvL1G48BFucJ3tFflSeQ==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-freebsd-arm64": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.31.tgz",
-      "integrity": "sha512-t85bS6jbRpmdjr4pdr/FY/fpx8lo1vv9S7BAs2EsXKJQhRDMIiC3QW+k2acYJoRuqirlvJcJVFQGCq/PfyC1kA==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-32": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.31.tgz",
-      "integrity": "sha512-XYtOk/GodSkv+UOYVwryGpGPuFnszsMvRMKq6cIUfFfdssHuKDsU9IZveyCG44J106J39ABenQ5EetbYtVJHUw==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-64": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.31.tgz",
-      "integrity": "sha512-Zf9CZxAxaXWHLqCg/QZ/hs0RU0XV3IBxV+ENQzy00S4QOTnZAvSLgPciILHHrVJ0lPIlb4XzAqlLM5y6iI2LIw==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-arm": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.31.tgz",
-      "integrity": "sha512-RpiaeHPRlgCCDskxoyIsI49BhcDtZ4cl8+SLffizDm0yMNWP538SUg0ezQ2TTOPj3/svaGIbkRDwYtAon0Sjkg==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-arm64": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.31.tgz",
-      "integrity": "sha512-V/H0tv+xpQ9IOHM+o85oCKNNidIEc5CcnDWl0V+hPd2F03dqdbFkWPBGphx8rD4JSQn6UefUQ1iH7y1qIzO8Fw==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-mips64le": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.31.tgz",
-      "integrity": "sha512-9/oBfAckInRuUg6AEgdCLLn6KJ6UOJDOLmUinTsReVSg6AfV6wxYQJq9iQM2idRogP7GUpomJ+bvCdWXpotQRQ==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-ppc64le": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.31.tgz",
-      "integrity": "sha512-NMcb14Pg+8q8raGkzor9/R3vQwKzgxE3694BtO2SDLBwJuL2C1dQ1ZtM1t7ZvArQBgT8RiZVxb0/3fD+qGNk7g==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-riscv64": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.31.tgz",
-      "integrity": "sha512-l13yvmsVfawAnoYfcpuvml+nTlrOmtdceXYufSkXl2DOb0JKcuR6ARlAzuQCDcpo49SOJy1cCxpwlOIsUQBfzA==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-s390x": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.31.tgz",
-      "integrity": "sha512-GIwV9mY3koYja9MCSkKLk1P7rj+MkPV0UsGsZ575hEcIBrXeKN9jBi6X/bxDDPEN/SUAH35cJhBNrZU4x9lEfg==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-netbsd-64": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.31.tgz",
-      "integrity": "sha512-bJ+pyLvKQm+Obp5k7/Wk8e9Gdkls56F1aiI3uptoIfOIUqsZImH7pDyTrSufwqsFp62kO9LRuwXnjDwQtPyhFQ==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-openbsd-64": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.31.tgz",
-      "integrity": "sha512-NRAAPPca05H9j9Xab0kVXK0V6/pyZGGy8d2Y8KS0BMwWEydlD4KCJDmH8/7bWCKYLRGOOCE9/GPBJyPWHFW3sg==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-sunos-64": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.31.tgz",
-      "integrity": "sha512-9uA+V8w9Eehu4ldb95lPWdgCMcMO5HH6pXmfkk5usn3JsSZxKdLKsXB4hYgP80wscZvVYXJl2G+KNxsUTfPhZw==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-windows-32": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.31.tgz",
-      "integrity": "sha512-VGdncQTqoxD9q3v/dk0Yugbmx2FzOkcs0OemBYc1X9KXOLQYH0uQbLJIckZdZOC3J+JKSExbYFrzYCOwWPuNyA==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-windows-64": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.31.tgz",
-      "integrity": "sha512-v/2ye5zBqpmCzi3bLCagStbNQlnOsY7WtMrD2Q0xZxeSIXONxji15KYtVee5o7nw4lXWbQSS1BL8G6BBMvtq4A==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-windows-arm64": {
-      "version": "0.14.31",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.31.tgz",
-      "integrity": "sha512-RXeU42FJoG1sriNHg73h4S+5B7L/gw+8T7U9u8IWqSSEbY6fZvBh4uofugiU1szUDqqP00GHwZ09WgYe3lGZiw==",
-      "dev": true,
-      "optional": true
-    },
-    "fast-xml-parser": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
-      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
-    },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "optional": true
-    },
-    "make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
-    },
-    "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-    },
-    "source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "ts-node": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
-      "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
-      "dev": true,
-      "requires": {
-        "@cspotcode/source-map-support": "0.7.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.0",
-        "yn": "3.1.1"
-      }
-    },
-    "tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-    },
-    "typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
-      "dev": true
-    },
-    "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-    },
-    "v8-compile-cache-lib": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
-      "integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==",
-      "dev": true
-    },
-    "yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true
     }
   }
 }

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -10,18 +10,18 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@types/aws-lambda": "^8.10.93",
+    "@types/aws-lambda": "^8.10.116",
     "@types/node": "17.0.23",
-    "aws-cdk": "^2.19.0",
-    "esbuild": "^0.14.31",
-    "ts-node": "^10.7.0",
-    "typescript": "^4.6.3"
+    "aws-cdk": "^2.82.0",
+    "esbuild": "^0.14.54",
+    "ts-node": "^10.9.1",
+    "typescript": "^4.9.5"
   },
   "dependencies": {
-    "@aws-sdk/client-ivs": "^3.58.0",
-    "@aws-sdk/client-s3": "^3.58.0",
-    "aws-cdk-lib": "2.19.0",
-    "constructs": "^10.0.106",
-    "source-map-support": "^0.5.16"
+    "@aws-sdk/client-ivs": "^3.345.0",
+    "@aws-sdk/client-s3": "^3.345.0",
+    "aws-cdk-lib": "^2.82.0",
+    "constructs": "^10.2.44",
+    "source-map-support": "^0.5.21"
   }
 }


### PR DESCRIPTION
*Description of changes:*
Support stitching fragmented recordings with the `reconnectWindowSeconds` feature. This allows fragmented recordings caused by short disconnects to be stitched into a single recording. The default value is `60 seconds` and can be modified in `cdk/config.json`. Streams that disconnect and reconnect within 60 seconds will be treated as a single recorded video.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
